### PR TITLE
Упростил/ускорил проверку

### DIFF
--- a/Tests/ValidationRules.Replication.StateInitialization.Tests/Firm/FirmShouldHaveLimitedCategoryCount.cs
+++ b/Tests/ValidationRules.Replication.StateInitialization.Tests/Firm/FirmShouldHaveLimitedCategoryCount.cs
@@ -89,4 +89,3 @@ namespace NuClear.ValidationRules.Replication.StateInitialization.Tests
                     });
     }
 }
-


### PR DESCRIPTION
Тесты проходят, на тестовой среде результат запроса идентичен (отличается порядком записей - роли не играет)
На тестовой среде запрос выполняется заметно быстрее (5-6 секунд против 8-11).
Читается (на мой взгляд) проще.