### PR TITLE
Опитимизация колонки Source

### DIFF
--- a/Schemas/Price.Aggregates.sql
+++ b/Schemas/Price.Aggregates.sql
@@ -103,8 +103,6 @@ create table PriceAggregates.OrderPosition(
     FirmAddressId bigint NULL,
 
     ThemeId bigint NULL,
-
-    Source nvarchar(16) NULL,
 )
 create index IX_OrderPosition_OrderId ON PriceAggregates.OrderPosition (OrderId)
 go
@@ -123,7 +121,7 @@ create table PriceAggregates.OrderDeniedPosition(
     Category1Id bigint NULL,
     FirmAddressId bigint NULL,
 
-    Source nvarchar(16) not null,
+    Source int not null,
 )
 create index IX_OrderDeniedPosition_OrderId_DeniedPositionId_BindingType
 on [PriceAggregates].[OrderDeniedPosition] ([OrderId],[DeniedPositionId],[BindingType])
@@ -144,7 +142,7 @@ create table PriceAggregates.OrderAssociatedPosition(
     Category1Id bigint NULL,
     FirmAddressId bigint NULL,
 
-	Source nvarchar(16) not null,
+	Source int not null,
 )
 create index IX_OrderAssociatedPosition_OrderId_PrincipalPositionId_BindingType
 on [PriceAggregates].[OrderAssociatedPosition] ([OrderId],[PrincipalPositionId],[BindingType])

--- a/Tests/ValidationRules.Replication.StateInitialization.Tests/Price/AssociatedPositionWithoutPrincipal.cs
+++ b/Tests/ValidationRules.Replication.StateInitialization.Tests/Price/AssociatedPositionWithoutPrincipal.cs
@@ -27,8 +27,8 @@ namespace NuClear.ValidationRules.Replication.StateInitialization.Tests
                     new Facts::RulesetRule { RuleType = 1, DependentPositionId = 6, PrincipalPositionId = 8 },
                     new Facts::RulesetRule { RuleType = 1, DependentPositionId = 4, PrincipalPositionId = 10 })
                 .Aggregate(
-                    new Aggregates::Order.OrderAssociatedPosition { OrderId = 1, CauseOrderPositionId = 2, CausePackagePositionId = 4, CauseItemPositionId = 6, PrincipalPositionId = 8, HasNoBinding = true, Source = Aggregates::Source.Opa | Aggregates::Source.Ruleset },
-                    new Aggregates::Order.OrderAssociatedPosition { OrderId = 1, CauseOrderPositionId = 2, CausePackagePositionId = 4, CauseItemPositionId = 4, PrincipalPositionId = 10, HasNoBinding = true, Source = Aggregates::Source.Pkg | Aggregates::Source.Ruleset });
+                    new Aggregates::Order.OrderAssociatedPosition { OrderId = 1, CauseOrderPositionId = 2, CausePackagePositionId = 4, CauseItemPositionId = 6, PrincipalPositionId = 8, HasNoBinding = true, Source = Aggregates::PositionSources.Opa | Aggregates::PositionSources.Ruleset },
+                    new Aggregates::Order.OrderAssociatedPosition { OrderId = 1, CauseOrderPositionId = 2, CausePackagePositionId = 4, CauseItemPositionId = 4, PrincipalPositionId = 10, HasNoBinding = true, Source = Aggregates::PositionSources.Pkg | Aggregates::PositionSources.Ruleset });
 
         // ReSharper disable once UnusedMember.Local
         private static ArrangeMetadataElement AssociatedPositionWithoutPrincipal

--- a/Tests/ValidationRules.Replication.StateInitialization.Tests/Price/AssociatedPositionWithoutPrincipal.cs
+++ b/Tests/ValidationRules.Replication.StateInitialization.Tests/Price/AssociatedPositionWithoutPrincipal.cs
@@ -27,8 +27,8 @@ namespace NuClear.ValidationRules.Replication.StateInitialization.Tests
                     new Facts::RulesetRule { RuleType = 1, DependentPositionId = 6, PrincipalPositionId = 8 },
                     new Facts::RulesetRule { RuleType = 1, DependentPositionId = 4, PrincipalPositionId = 10 })
                 .Aggregate(
-                    new Aggregates::Order.OrderAssociatedPosition { OrderId = 1, CauseOrderPositionId = 2, CausePackagePositionId = 4, CauseItemPositionId = 6, PrincipalPositionId = 8, HasNoBinding = true, Source = "opas by ruleset" },
-                    new Aggregates::Order.OrderAssociatedPosition { OrderId = 1, CauseOrderPositionId = 2, CausePackagePositionId = 4, CauseItemPositionId = 4, PrincipalPositionId = 10, HasNoBinding = true, Source = "pkgs by ruleset" });
+                    new Aggregates::Order.OrderAssociatedPosition { OrderId = 1, CauseOrderPositionId = 2, CausePackagePositionId = 4, CauseItemPositionId = 6, PrincipalPositionId = 8, HasNoBinding = true, Source = Aggregates::Source.Opa | Aggregates::Source.Ruleset },
+                    new Aggregates::Order.OrderAssociatedPosition { OrderId = 1, CauseOrderPositionId = 2, CausePackagePositionId = 4, CauseItemPositionId = 4, PrincipalPositionId = 10, HasNoBinding = true, Source = Aggregates::Source.Pkg | Aggregates::Source.Ruleset });
 
         // ReSharper disable once UnusedMember.Local
         private static ArrangeMetadataElement AssociatedPositionWithoutPrincipal

--- a/Tests/ValidationRules.Replication.StateInitialization.Tests/TestCaseMetadataSource.Order.cs
+++ b/Tests/ValidationRules.Replication.StateInitialization.Tests/TestCaseMetadataSource.Order.cs
@@ -151,7 +151,7 @@ namespace NuClear.ValidationRules.Replication.StateInitialization.Tests
                     new Facts::DeniedPosition { Id = 11, PriceId = 9, PositionId = 7, PositionDeniedId = 14 })
                 .Aggregate(
                     new Aggregates::Order { Id = 1 },
-                    new Aggregates::Order.OrderDeniedPosition { OrderId = 1, CauseOrderPositionId = 2, CausePackagePositionId = 7, CauseItemPositionId = 7, DeniedPositionId = 14, HasNoBinding = true, Source = "opas by price" },
+                    new Aggregates::Order.OrderDeniedPosition { OrderId = 1, CauseOrderPositionId = 2, CausePackagePositionId = 7, CauseItemPositionId = 7, DeniedPositionId = 14, HasNoBinding = true, Source = Aggregates::Source.Opa | Aggregates::Source.Price },
                     new Aggregates::Order.OrderPricePosition {OrderId = 1, OrderPositionId = 2, PriceId = 9, OrderPositionName = "Position7", IsActive = true });
     }
 }

--- a/Tests/ValidationRules.Replication.StateInitialization.Tests/TestCaseMetadataSource.Order.cs
+++ b/Tests/ValidationRules.Replication.StateInitialization.Tests/TestCaseMetadataSource.Order.cs
@@ -151,7 +151,7 @@ namespace NuClear.ValidationRules.Replication.StateInitialization.Tests
                     new Facts::DeniedPosition { Id = 11, PriceId = 9, PositionId = 7, PositionDeniedId = 14 })
                 .Aggregate(
                     new Aggregates::Order { Id = 1 },
-                    new Aggregates::Order.OrderDeniedPosition { OrderId = 1, CauseOrderPositionId = 2, CausePackagePositionId = 7, CauseItemPositionId = 7, DeniedPositionId = 14, HasNoBinding = true, Source = Aggregates::Source.Opa | Aggregates::Source.Price },
-                    new Aggregates::Order.OrderPricePosition {OrderId = 1, OrderPositionId = 2, PriceId = 9, OrderPositionName = "Position7", IsActive = true });
+                    new Aggregates::Order.OrderDeniedPosition { OrderId = 1, CauseOrderPositionId = 2, CausePackagePositionId = 7, CauseItemPositionId = 7, DeniedPositionId = 14, HasNoBinding = true, Source = Aggregates::PositionSources.Opa | Aggregates::PositionSources.Price },
+                    new Aggregates::Order.OrderPricePosition {OrderId = 1, OrderPositionId = 2, PriceId = 9, OrderPositionName = "Position7", IsActive = true }).RunOnlyThis();
     }
 }

--- a/ValidationRules.Replication/PriceRules/Aggregates/OrderAggregateRootActor.cs
+++ b/ValidationRules.Replication/PriceRules/Aggregates/OrderAggregateRootActor.cs
@@ -264,7 +264,7 @@ namespace NuClear.ValidationRules.Replication.PriceRules.Aggregates
                             Category3Id = category.L3Id,
                             FirmAddressId = opa.FirmAddressId,
                             Category1Id = category.L1Id,
-                            Source = "opas",
+                            Source = Source.Opa,
                         };
 
                 var pkgs =
@@ -285,7 +285,7 @@ namespace NuClear.ValidationRules.Replication.PriceRules.Aggregates
                             Category3Id = category.L3Id,
                             FirmAddressId = opa.FirmAddressId,
                             Category1Id = category.L1Id,
-                            Source = "pkgs",
+                            Source = Source.Pkg,
                         };
 
                 var deniedByPrice =
@@ -306,7 +306,7 @@ namespace NuClear.ValidationRules.Replication.PriceRules.Aggregates
                             DeniedPositionId = denied.PositionDeniedId,
                             BindingType = denied.ObjectBindingType,
 
-                            Source = bingingObject.Source + " by price",
+                            Source = bingingObject.Source | Source.Price,
                         };
 
                 var deniedByRuleset =
@@ -327,7 +327,7 @@ namespace NuClear.ValidationRules.Replication.PriceRules.Aggregates
                         DeniedPositionId = denied.PrincipalPositionId,
                         BindingType = denied.ObjectBindingType,
 
-                        Source = bingingObject.Source + " by ruleset",
+                        Source = bingingObject.Source | Source.Ruleset,
                     };
 
                 return deniedByPrice.Union(deniedByRuleset);
@@ -379,7 +379,7 @@ namespace NuClear.ValidationRules.Replication.PriceRules.Aggregates
                         Category3Id = category.L3Id,
                         opa.FirmAddressId,
                         Category1Id = category.L1Id,
-                        Source = "opas",
+                        Source = Source.Opa,
                     };
 
                 var pkgs =
@@ -400,7 +400,7 @@ namespace NuClear.ValidationRules.Replication.PriceRules.Aggregates
                         Category3Id = category.L3Id,
                         opa.FirmAddressId,
                         Category1Id = category.L1Id,
-                        Source = "pkgs",
+                        Source = Source.Pkg,
                     };
 
                 var associatedByPrice =
@@ -421,7 +421,7 @@ namespace NuClear.ValidationRules.Replication.PriceRules.Aggregates
                         PrincipalPositionId = ap.PositionId,
                         BindingType = ap.ObjectBindingType,
 
-                        Source = bingingObject.Source + " by price",
+                        Source = bingingObject.Source | Source.Price,
                     };
 
                 var associatedByRuleset =
@@ -442,7 +442,7 @@ namespace NuClear.ValidationRules.Replication.PriceRules.Aggregates
                         PrincipalPositionId = associated.PrincipalPositionId,
                         BindingType = associated.ObjectBindingType,
 
-                        Source = bingingObject.Source + " by ruleset",
+                        Source = bingingObject.Source | Source.Ruleset,
                     };
 
                 return associatedByPrice.Union(associatedByRuleset);

--- a/ValidationRules.Replication/PriceRules/Aggregates/OrderAggregateRootActor.cs
+++ b/ValidationRules.Replication/PriceRules/Aggregates/OrderAggregateRootActor.cs
@@ -264,7 +264,7 @@ namespace NuClear.ValidationRules.Replication.PriceRules.Aggregates
                             Category3Id = category.L3Id,
                             FirmAddressId = opa.FirmAddressId,
                             Category1Id = category.L1Id,
-                            Source = Source.Opa,
+                            Source = PositionSources.Opa,
                         };
 
                 var pkgs =
@@ -285,7 +285,7 @@ namespace NuClear.ValidationRules.Replication.PriceRules.Aggregates
                             Category3Id = category.L3Id,
                             FirmAddressId = opa.FirmAddressId,
                             Category1Id = category.L1Id,
-                            Source = Source.Pkg,
+                            Source = PositionSources.Pkg,
                         };
 
                 var deniedByPrice =
@@ -306,7 +306,7 @@ namespace NuClear.ValidationRules.Replication.PriceRules.Aggregates
                             DeniedPositionId = denied.PositionDeniedId,
                             BindingType = denied.ObjectBindingType,
 
-                            Source = bingingObject.Source | Source.Price,
+                            Source = bingingObject.Source | PositionSources.Price,
                         };
 
                 var deniedByRuleset =
@@ -327,7 +327,7 @@ namespace NuClear.ValidationRules.Replication.PriceRules.Aggregates
                         DeniedPositionId = denied.PrincipalPositionId,
                         BindingType = denied.ObjectBindingType,
 
-                        Source = bingingObject.Source | Source.Ruleset,
+                        Source = bingingObject.Source | PositionSources.Ruleset,
                     };
 
                 return deniedByPrice.Union(deniedByRuleset);
@@ -379,7 +379,7 @@ namespace NuClear.ValidationRules.Replication.PriceRules.Aggregates
                         Category3Id = category.L3Id,
                         opa.FirmAddressId,
                         Category1Id = category.L1Id,
-                        Source = Source.Opa,
+                        Source = PositionSources.Opa,
                     };
 
                 var pkgs =
@@ -400,7 +400,7 @@ namespace NuClear.ValidationRules.Replication.PriceRules.Aggregates
                         Category3Id = category.L3Id,
                         opa.FirmAddressId,
                         Category1Id = category.L1Id,
-                        Source = Source.Pkg,
+                        Source = PositionSources.Pkg,
                     };
 
                 var associatedByPrice =
@@ -421,7 +421,7 @@ namespace NuClear.ValidationRules.Replication.PriceRules.Aggregates
                         PrincipalPositionId = ap.PositionId,
                         BindingType = ap.ObjectBindingType,
 
-                        Source = bingingObject.Source | Source.Price,
+                        Source = bingingObject.Source | PositionSources.Price,
                     };
 
                 var associatedByRuleset =
@@ -442,7 +442,7 @@ namespace NuClear.ValidationRules.Replication.PriceRules.Aggregates
                         PrincipalPositionId = associated.PrincipalPositionId,
                         BindingType = associated.ObjectBindingType,
 
-                        Source = bingingObject.Source | Source.Ruleset,
+                        Source = bingingObject.Source | PositionSources.Ruleset,
                     };
 
                 return associatedByPrice.Union(associatedByRuleset);

--- a/ValidationRules.Storage/Model/PriceRules/Aggregates/Order.cs
+++ b/ValidationRules.Storage/Model/PriceRules/Aggregates/Order.cs
@@ -43,7 +43,7 @@ namespace NuClear.ValidationRules.Storage.Model.PriceRules.Aggregates
             public long? FirmAddressId { get; set; }
             public long? Category1Id { get; set; }
 
-            public Source Source { get; set; }
+            public PositionSources Source { get; set; }
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace NuClear.ValidationRules.Storage.Model.PriceRules.Aggregates
             public long? FirmAddressId { get; set; }
             public long? Category1Id { get; set; }
 
-            public Source Source { get; set; }
+            public PositionSources Source { get; set; }
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace NuClear.ValidationRules.Storage.Model.PriceRules.Aggregates
     }
 
     [Flags]
-    public enum Source
+    public enum PositionSources
     {
         None = 0,
 

--- a/ValidationRules.Storage/Model/PriceRules/Aggregates/Order.cs
+++ b/ValidationRules.Storage/Model/PriceRules/Aggregates/Order.cs
@@ -1,4 +1,6 @@
-﻿namespace NuClear.ValidationRules.Storage.Model.PriceRules.Aggregates
+﻿using System;
+
+namespace NuClear.ValidationRules.Storage.Model.PriceRules.Aggregates
 {
     /// <summary>
     /// Импортированная из ERM сущность заказа
@@ -41,7 +43,7 @@
             public long? FirmAddressId { get; set; }
             public long? Category1Id { get; set; }
 
-            public string Source { get; set; }
+            public Source Source { get; set; }
         }
 
         /// <summary>
@@ -64,7 +66,7 @@
             public long? FirmAddressId { get; set; }
             public long? Category1Id { get; set; }
 
-            public string Source { get; set; }
+            public Source Source { get; set; }
         }
 
         /// <summary>
@@ -94,5 +96,17 @@
             public long OrderId { get; set; }
             public long CategoryCode { get; set; }
         }
+    }
+
+    [Flags]
+    public enum Source
+    {
+        None = 0,
+
+        Opa = 1,
+        Pkg = 1 << 1,
+
+        Price = 1 << 2,
+        Ruleset = 1 << 3,
     }
 }


### PR DESCRIPTION
Таблицы OrderDeniedPosition, OrderAssociatedPosition большие по объёму (~1Gb).
Чтобы немного уменьшить расходы на храниение, сделал поле Source вместо nvarchar(16) как int, а в коде как flagged enum.

Fixes #97