### PR TITLE
Исправил NullReference при выборке ошибок по версии

### DIFF
--- a/Schemas/Messages.sql
+++ b/Schemas/Messages.sql
@@ -38,7 +38,8 @@ go
 CREATE INDEX [IX_ValidationResult_Resolved] ON [Messages].[ValidationResult] ([Resolved])
 CREATE INDEX [IX_ValidationResult_VersionId] ON [Messages].[ValidationResult] ([VersionId])
 
-CREATE NONCLUSTERED INDEX IX_ValidationResult_MessageType_VersionId_Resolved
-ON [Messages].[ValidationResult] ([MessageType],[VersionId],[Resolved])
-INCLUDE ([MessageParams],[PeriodStart],[PeriodEnd],[ProjectId],[OrderId],[Result])
+-- индекс используется при выборке нерешённых ошибок по версии
+CREATE NONCLUSTERED INDEX IX_ValidationResult_Resolved_VersionId
+ON [Messages].[ValidationResult] ([Resolved],[VersionId])
+INCLUDE ([MessageType],[MessageParams],[PeriodStart],[PeriodEnd],[ProjectId],[OrderId],[Result])
 GO


### PR DESCRIPTION
Судя по всему там на самом деле был тайм-аут, но это как-то скрывалось.
А его причина была в том, что sql выбирал "Nested Loops" вместо "Hash Match"
С этим индексом - всё ок.