### PR TITLE
Исправил пересчёт правил при изменении value-object

### DIFF
--- a/ValidationRules.Replication/AggregateRootActor.cs
+++ b/ValidationRules.Replication/AggregateRootActor.cs
@@ -47,7 +47,7 @@ namespace NuClear.ValidationRules.Replication
             where TAccessor : IStorageBasedDataObjectAccessor<TEntity>, IDataChangesHandler<TEntity>
             where TEntity : class
         {
-            return new ValueObjectActor<TEntity>(_query, repository, _equalityComparerFactory, accessor);
+            return new ValueObjectActor<TEntity>(new ValueObjectChangesProvider<TEntity>(_query, accessor, _equalityComparerFactory), repository, accessor);
         }
 
         private sealed class EntityActor<TEntity> : EntityActorBase<TEntity> where TEntity : class


### PR DESCRIPTION
Оказывается, использовался конструктор, который предназначен для
value-object, не привидящих ни к каким дальнейшим событиям.

fix ERM-10468