### PR TITLE
Добавил поддержку Load среды

### DIFF
--- a/Environments/ConvertUseCases.Load.config
+++ b/Environments/ConvertUseCases.Load.config
@@ -1,0 +1,29 @@
+﻿<!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+
+  <appSettings>
+    <add key="ReceiverEnityPath" value="{SourceTopic}/Subscriptions/{SourceSubscription}"
+         xdt:Transform="Replace" xdt:Locator="Match(key)"/>
+    <add key="SenderEnityPath" value="{DestTopic}"
+         xdt:Transform="Replace" xdt:Locator="Match(key)"/>
+
+    <add key="PrefetchCount" value="100"
+         xdt:Transform="Replace" xdt:Locator="Match(key)"/>
+    <add key="TargetEnvironmentName" value="{EnvType}.{Country}"
+         xdt:Transform="Replace" xdt:Locator="Match(key)"/>
+    <add key="EntryPointName" value="ConvertUseCases"
+         xdt:Transform="Replace" xdt:Locator="Match(key)"/>
+    <add key="LogstashUri" value="http://logstash.prod.erm.2gis.ru:8194"
+         xdt:Transform="Replace" xdt:Locator="Match(key)"/>
+  </appSettings>
+  
+  <connectionStrings>
+	  <add name="Source" connectionString="Endpoint=sb://uk-erm-es10.2gis.local/Erm-{EnvType}{Country},sb://uk-erm-es11.2gis.local/Erm-{EnvType}{Country};StsEndpoint=https://uk-erm-es10.2gis.local:9355/Erm-{EnvType}{Country},https://uk-erm-es11.2gis.local:9355/Erm-{EnvType}{Country};RuntimePort=9354;ManagementPort=9355;OperationTimeout=00:00:05"
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+	  <add name="Dest" connectionString="Endpoint=sb://uk-erm-es10.2gis.local/Erm-{EnvType}{Country},sb://uk-erm-es11.2gis.local/Erm-{EnvType}{Country};StsEndpoint=https://uk-erm-es10.2gis.local:9355/Erm-{EnvType}{Country},https://uk-erm-es11.2gis.local:9355/Erm-{EnvType}{Country};RuntimePort=9354;ManagementPort=9355;OperationTimeout=00:00:05"
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    <add name="Logging" connectionString="http://logstash.prod.erm.2gis.ru:8194"
+         xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+  </connectionStrings>
+
+</configuration>

--- a/Environments/Erm.Load.config
+++ b/Environments/Erm.Load.config
@@ -33,7 +33,7 @@
          xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
     <add name="Infrastructure" connectionString="Data Source={DBHost};Initial Catalog=ErmInfrastructure;Integrated Security=True"
          xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
-    <add name="ServiceBus" connectionString="Endpoint=sb://service-bus.prod.erm.2gis.ru/ERM-{EnvType}{Country};StsEndpoint=https://service-bus.prod.erm.2gis.ru:9355/ERM-{EnvType}{Country};RuntimePort=9354;ManagementPort=9355;OperationTimeout=00:00:05"
+    <add name="ServiceBus" connectionString="Endpoint=sb://uk-erm-es10.2gis.local/Erm-{EnvType}{Country},sb://uk-erm-es11.2gis.local/Erm-{EnvType}{Country};StsEndpoint=https://uk-erm-es10.2gis.local:9355/Erm-{EnvType}{Country},https://uk-erm-es11.2gis.local:9355/Erm-{EnvType}{Country};RuntimePort=9354;ManagementPort=9355;OperationTimeout=00:00:05"
          xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
   </connectionStrings>
 

--- a/Environments/Erm.config
+++ b/Environments/Erm.config
@@ -6,8 +6,6 @@
          xdt:Transform="Replace" xdt:Locator="Match(key)"/>
     <add key="TargetEnvironmentName" value="{EnvType}.{Country}"
          xdt:Transform="Replace" xdt:Locator="Match(key)"/>
-    <add key="IntegrationApplicationName" value="ERM.{DBSuffix}.Search"
-         xdt:Transform="Replace" xdt:Locator="Match(key)"/>
     <add key="SchedulerName" value="ReplicationService.ValidationRules.Scheduler.{EnvType}.{Country}"
          xdt:Transform="Replace" xdt:Locator="Match(key)"/>
     <add key="ErmEventsFlowTopic" value="{ErmEventsFlowTopic}"

--- a/Environments/Templates/Erm.Test.config
+++ b/Environments/Templates/Erm.Test.config
@@ -2,15 +2,9 @@
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
 
   <appSettings>
-    <add key="ErmAddress" value="https://web-app{EnvNum}.test.erm.2gis.ru"
-         xdt:Transform="Replace" xdt:Locator="Match(key)" />
-    <add key="ResultDeliveryHour" value="11"
-         xdt:Transform="Replace" xdt:Locator="Match(key)" />
     <add key="JobStoreType" value="TX"
          xdt:Transform="Replace" xdt:Locator="Match(key)"/>
     <add key="TargetEnvironmentName" value="{EnvType}.{EnvNum}"
-         xdt:Transform="Replace" xdt:Locator="Match(key)"/>
-    <add key="IntegrationApplicationName" value="ERM{EnvNum}.Search"
          xdt:Transform="Replace" xdt:Locator="Match(key)"/>
     <add key="SchedulerName" value="ReplicationService.ValidationRules.Scheduler.{EnvType}.{EnvNum}"
          xdt:Transform="Replace" xdt:Locator="Match(key)"/>

--- a/NuClear.River.ValidationRules.sln
+++ b/NuClear.River.ValidationRules.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26127.0
+VisualStudioVersion = 15.0.26206.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{C1C7C6AC-4AAC-45E4-94AC-DEC47A72F447}"
 	ProjectSection(SolutionItems) = preProject
@@ -13,8 +13,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Environments", "Environments", "{8F3C0046-1F47-4C8E-8B03-D35E96686C6F}"
 	ProjectSection(SolutionItems) = preProject
 		Environments\ConvertUseCases.config = Environments\ConvertUseCases.config
+		Environments\ConvertUseCases.Load.config = Environments\ConvertUseCases.Load.config
 		Environments\ConvertUseCases.Production.config = Environments\ConvertUseCases.Production.config
 		Environments\Erm.config = Environments\Erm.config
+		Environments\Erm.Load.config = Environments\Erm.Load.config
 		Environments\Erm.Production.config = Environments\Erm.Production.config
 		Environments\quartz.Production.config = Environments\quartz.Production.config
 		Environments\quartz.Production.Russia.config = Environments\quartz.Production.Russia.config

--- a/ValidationRules.Replication.Host/App.config
+++ b/ValidationRules.Replication.Host/App.config
@@ -7,7 +7,6 @@
     <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" requirePermission="false" />
   </configSections>
   <appSettings>
-    <add key="IntegrationApplicationName" value="ERM20.Search" />
     <add key="ErmEventsFlowTopic" value="topic.performedoperations.production.russia.import" />
     <add key="EntryPointName" value="River.Replication.ValidationRules" />
     <add key="TargetEnvironmentName" value="Dev" />
@@ -20,7 +19,6 @@
     <!-- in seconds -->
     <add key="ReplicationBatchSize" value="1000" />
     <add key="IdentityServiceUrl" value="https://identity.api.test.erm.2gis.ru" />
-    <add key="ErmAddress" value="https://web-app20.test.erm.2gis.ru" />
     <add key="ArchiveVersionsInterval" value="1.00:00:00" />
   </appSettings>
   <connectionStrings>
@@ -47,24 +45,4 @@
       <level value="DEBUG" />
     </root>
   </log4net>
-  <system.serviceModel>
-    <bindings>
-      <netTcpBinding>
-        <binding name="netTcpConfiguration" maxReceivedMessageSize="2000000000" receiveTimeout="01:00:00" sendTimeout="01:00:00" />
-      </netTcpBinding>
-    </bindings>
-    <client>
-      <!-- service bus broker -->
-      <endpoint name="NetTcpBinding_IBrokerApiSender" address="net.tcp://uk-bus-test01.2gis.local:8106/BrokerApiService" binding="netTcpBinding" bindingConfiguration="netTcpConfiguration" contract="ServiceReference.IBrokerApiSender">
-        <identity>
-          <servicePrincipalName value="host/uk-bus-test01.2gis.local" />
-        </identity>
-      </endpoint>
-      <endpoint name="NetTcpBinding_IBrokerApiReceiver" address="net.tcp://uk-bus-test01.2gis.local:8106/BrokerApiService" binding="netTcpBinding" bindingConfiguration="netTcpConfiguration" contract="ServiceReference.IBrokerApiReceiver">
-        <identity>
-          <servicePrincipalName value="host/uk-bus-test01.2gis.local" />
-        </identity>
-      </endpoint>
-    </client>
-  </system.serviceModel>
 </configuration>

--- a/build/metadata.transform.psm1
+++ b/build/metadata.transform.psm1
@@ -14,7 +14,6 @@ $DBSuffixes = @{
 	'Ukraine' = 'UA'
 	'Kazakhstan' = 'KZ'
 	'Kyrgyzstan' = 'KG'
-	'Italy' = 'IT'
 }
 
 function Get-DBHostMetadata($Context){
@@ -34,6 +33,9 @@ function Get-DBHostMetadata($Context){
 		'Production' {
 			$dbHost = 'uk-sql20\erm'
 		}
+		'Load' {
+			$dbHost = 'uk-test-sql01\MSSQL2016'
+		}
 	}
 
 	return @{ 'DBHost' = $dbHost }
@@ -52,6 +54,9 @@ function Get-XdtMetadata($Context){
 				'Test' {
 					$xdt += @("Templates\ConvertUseCases.Test.config")
 				}
+				'Load' {
+					$xdt += @("ConvertUseCases.Load.config")
+				}
 				default {
 					$xdt += @("ConvertUseCases.config")
 				}
@@ -68,6 +73,9 @@ function Get-XdtMetadata($Context){
 				}
 				'Production' {
 					$xdt += @("Erm.Production.config")
+				}
+				'Load' {
+					$xdt += @("Erm.Load.config")
 				}
 				default {
 					$xdt += @("Erm.config")


### PR DESCRIPTION
Ещё актуализировал метаданные для web из ERM:
- настройки AppPool как в ERM
- настроки AppOffline как в ERM

Ещё повычищал неиспользуемых настроек:
- удалил настройки для Италии, т.к. в ERM её тоже удалили
- удалил настройки ErmAddress, ResultDeliveryHour времён публикации в slack
- удалил настройку IntegrationApplicationName и секцию system.serviceModel, т.к. мы не слушаем corporate bus совсем