### PR TITLE
Исправил проверку наличия ограничения по cpc

### DIFF
--- a/Tests/ValidationRules.Replication.StateInitialization.Tests/Project/OrderPositionCostPerClickMustBeSpecified.cs
+++ b/Tests/ValidationRules.Replication.StateInitialization.Tests/Project/OrderPositionCostPerClickMustBeSpecified.cs
@@ -1,4 +1,6 @@
-﻿using NuClear.DataTest.Metamodel.Dsl;
+﻿using System;
+
+using NuClear.DataTest.Metamodel.Dsl;
 using NuClear.ValidationRules.Storage.Identitites.EntityTypes;
 using NuClear.ValidationRules.Storage.Model.Messages;
 
@@ -39,7 +41,8 @@ namespace NuClear.ValidationRules.Replication.StateInitialization.Tests
                     new Facts::Position { Id = 5, SalesModel = 11 },
                     new Facts::Category { Id = 12, IsActiveNotDeleted = true },
                     new Facts::CategoryOrganizationUnit { CategoryId = 12 },
-                    new Facts::Project())
+                    new Facts::Project(),
+                    new Facts::CostPerClickCategoryRestriction { Begin = MonthStart(1), CategoryId = 12 })
                 .Aggregate(
                     // Заказ с позицией с покликовой моделью, но без ставки - есть ошибка
                     new Aggregates::Order { Id = 1, Begin = MonthStart(1), End = MonthStart(3) },
@@ -54,7 +57,8 @@ namespace NuClear.ValidationRules.Replication.StateInitialization.Tests
                     new Aggregates::Order.CategoryAdvertisement { OrderId = 3, OrderPositionId = 3, PositionId = 4, CategoryId = 12, SalesModel = 12 },
                     new Aggregates::Order.CostPerClickAdvertisement { OrderId = 3, OrderPositionId = 3, PositionId = 4, CategoryId = 12 },
 
-                    new Aggregates::Project.Category { CategoryId = 12 })
+                    new Aggregates::Project.Category { CategoryId = 12 },
+                    new Aggregates::Project.CostPerClickRestriction { CategoryId = 12, Begin = MonthStart(1), End = DateTime.MaxValue })
                 .Message(
                     new Messages::Version.ValidationResult
                         {

--- a/Tests/ValidationRules.Replication.StateInitialization.Tests/Project/ProjectMustContainCostPerClickMinimumRestriction.cs
+++ b/Tests/ValidationRules.Replication.StateInitialization.Tests/Project/ProjectMustContainCostPerClickMinimumRestriction.cs
@@ -19,48 +19,49 @@ namespace NuClear.ValidationRules.Replication.StateInitialization.Tests
                 .Config
                 .Name(nameof(ProjectMustContainCostPerClickMinimumRestriction))
                 .Fact(
+                    // Действует ограничение по 13-й рубрике (месяц 1)
                     new Facts::Order { Id = 1, BeginDistribution = MonthStart(1), EndDistributionPlan = MonthStart(3) },
                     new Facts::OrderPosition { Id = 1, OrderId = 1, PricePositionId = 5 },
-                    new Facts::OrderPositionCostPerClick { OrderPositionId = 1, CategoryId = 12, Amount = 1 },
-                    new Facts::OrderPositionCostPerClick { OrderPositionId = 1, CategoryId = 13, Amount = 1 },
+                    new Facts::OrderPositionCostPerClick { OrderPositionId = 1, CategoryId = 13, Amount = 2 },
+
+                    // Ограничение по 14-й рубрике обнуляет таковое по 13-й (месяц 2)
+                    new Facts::Order { Id = 2, BeginDistribution = MonthStart(2), EndDistributionPlan = MonthStart(3) },
+                    new Facts::OrderPosition { Id = 2, OrderId = 2, PricePositionId = 5 },
+                    new Facts::OrderPositionCostPerClick { OrderPositionId = 2, CategoryId = 13, Amount = 2 },
+
                     new Facts::Position { Id = 4 },
                     new Facts::PricePosition { Id = 5, PositionId = 4 },
+
                     new Facts::Category { Id = 12, IsActiveNotDeleted = true },
                     new Facts::Category { Id = 13, IsActiveNotDeleted = true },
+
                     new Facts::Project(),
-                    new Facts::CostPerClickCategoryRestriction { Begin = MonthStart(1), CategoryId = 13, MinCostPerClick = 2 })
+                    new Facts::CostPerClickCategoryRestriction { Begin = MonthStart(1), CategoryId = 13, MinCostPerClick = 2 },
+                    new Facts::CostPerClickCategoryRestriction { Begin = MonthStart(2), CategoryId = 14, MinCostPerClick = 2 })
                 .Aggregate(
                     new Aggregates::Order { Id = 1, Begin = MonthStart(1), End = MonthStart(3) },
-                    new Aggregates::Order.CostPerClickAdvertisement { OrderId = 1, OrderPositionId = 1, PositionId = 4, CategoryId = 12, Bid = 1 },
-                    new Aggregates::Order.CostPerClickAdvertisement { OrderId = 1, OrderPositionId = 1, PositionId = 4, CategoryId = 13, Bid = 1 },
+                    new Aggregates::Order.CostPerClickAdvertisement { OrderId = 1, OrderPositionId = 1, PositionId = 4, CategoryId = 13, Bid = 2 },
+
+                    new Aggregates::Order { Id = 2, Begin = MonthStart(2), End = MonthStart(3) },
+                    new Aggregates::Order.CostPerClickAdvertisement { OrderId = 2, OrderPositionId = 2, PositionId = 4, CategoryId = 13, Bid = 2 },
+
                     new Aggregates::Project(),
-                    new Aggregates::Project.CostPerClickRestriction { CategoryId = 13, Begin = MonthStart(1), End = DateTime.MaxValue, Minimum = 2 })
+                    new Aggregates::Project.CostPerClickRestriction { CategoryId = 13, Begin = MonthStart(1), End = MonthStart(2), Minimum = 2 },
+                    new Aggregates::Project.CostPerClickRestriction { CategoryId = 14, Begin = MonthStart(2), End = DateTime.MaxValue, Minimum = 2 })
                 .Message(
                     new Messages::Version.ValidationResult
                         {
                             MessageParams =
                                 new MessageParams(
-                                    new Reference<EntityTypeCategory>(12),
-                                    new Reference<EntityTypeProject>(0)).ToXDocument(),
+                                        new Reference<EntityTypeCategory>(13),
+                                        new Reference<EntityTypeProject>(0))
+                                    .ToXDocument(),
                             MessageType = (int)MessageTypeCode.ProjectMustContainCostPerClickMinimumRestriction,
                             Result = 1023,
-                            PeriodStart = MonthStart(1),
+                            PeriodStart = MonthStart(2),
                             PeriodEnd = MonthStart(3),
-                            OrderId = 1,
-                        },
-                    new Messages::Version.ValidationResult
-                        {
-                            MessageParams =
-                                new MessageParams(
-                                    new Reference<EntityTypeCategory>(13),
-                                    new Reference<EntityTypeOrderPosition>(1,
-                                        new Reference<EntityTypeOrder>(1),
-                                        new Reference<EntityTypePosition>(4))).ToXDocument(),
-                            MessageType = (int)MessageTypeCode.OrderPositionCostPerClickMustNotBeLessMinimum,
-                            Result = 1023,
-                            PeriodStart = MonthStart(1),
-                            PeriodEnd = MonthStart(3),
-                            OrderId = 1,
-                        });
+                            OrderId = 2,
+                        }
+                );
     }
 }

--- a/ValidationRules.Replication/ProjectRules/Validation/ProjectMustContainCostPerClickMinimumRestriction.cs
+++ b/ValidationRules.Replication/ProjectRules/Validation/ProjectMustContainCostPerClickMinimumRestriction.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 using NuClear.Storage.API.Readings;
 using NuClear.ValidationRules.Storage.Identitites.EntityTypes;
@@ -10,9 +11,10 @@ using Version = NuClear.ValidationRules.Storage.Model.Messages.Version;
 namespace NuClear.ValidationRules.Replication.ProjectRules.Validation
 {
     /// <summary>
-    /// Для проектов, где есть продажи в рубрики без указанного ограничения стоимости клика, должна выводиться ошибка.
+    /// Для проектов, где есть продажи в рубрики без указанного ограничения стоимости клика*, должна выводиться ошибка.
     /// "Для рубрики {0} в проекте {1} не указан минимальный CPC"
     /// 
+    /// * учитываются ограничения только самой свежей версии для города.
     /// Source: IsCostPerClickRestrictionMissingOrderValidationRule
     /// </summary>
     public sealed class ProjectMustContainCostPerClickMinimumRestriction : ValidationResultAccessorBase
@@ -28,26 +30,33 @@ namespace NuClear.ValidationRules.Replication.ProjectRules.Validation
 
         protected override IQueryable<Version.ValidationResult> GetValidationResults(IQuery query)
         {
-            var ruleResults =
-                from project in query.For<Project>()
-                from order in query.For<Order>().Where(x => x.ProjectId == project.Id)
+            // Даты, к наступлению которых требуется наличие действующих ограничений
+            var requiredRestrictions =
+                from order in query.For<Order>()
                 from bid in query.For<Order.CostPerClickAdvertisement>().Where(x => x.OrderId == order.Id)
-                let restrictionExist = query.For<Project.CostPerClickRestriction>().Any(x => x.ProjectId == order.ProjectId && x.CategoryId == bid.CategoryId)
+                let nextRelease = query.For<Project.NextRelease>().FirstOrDefault(x => x.ProjectId == order.ProjectId).Date
+                let referenceDate = nextRelease > order.Begin ? nextRelease : order.Begin
+                where referenceDate < order.End
+                select new { OrderId = order.Id, order.ProjectId, Begin = referenceDate, End = order.End, bid.CategoryId };
+
+            var ruleResults =
+                from req in requiredRestrictions
+                let restrictionExist = query.For<Project.CostPerClickRestriction>().Any(x => x.ProjectId == req.ProjectId && x.CategoryId == req.CategoryId && x.Begin <= req.Begin && x.End > req.Begin)
                 where !restrictionExist
                 select new Version.ValidationResult
-                    {
-                        MessageParams =
+                {
+                    MessageParams =
                             new MessageParams(
-                                    new Reference<EntityTypeCategory>(bid.CategoryId),
-                                    new Reference<EntityTypeProject>(order.ProjectId))
+                                    new Reference<EntityTypeCategory>(req.CategoryId),
+                                    new Reference<EntityTypeProject>(req.ProjectId))
                                 .ToXDocument(),
 
-                        PeriodStart = order.Begin,
-                        PeriodEnd = order.End,
-                        OrderId = order.Id,
+                    PeriodStart = req.Begin,
+                    PeriodEnd = req.End,
+                    OrderId = req.OrderId,
 
-                        Result = RuleResult,
-                    };
+                    Result = RuleResult,
+                };
 
             return ruleResults;
         }


### PR DESCRIPTION
Ограничение заканчивает действие при поступлении пакета новых, вне
зависимости от того, есть ли в пакете новых ограничение по данной
рубрике.