### PR TITLE
Добавил простейшее кеширование ValidationResults

### DIFF
--- a/ValidationRules.Replication/Messages/ValidationResultCache.cs
+++ b/ValidationRules.Replication/Messages/ValidationResultCache.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+
+using Version = NuClear.ValidationRules.Storage.Model.Messages.Version;
+
+namespace NuClear.ValidationRules.Replication.Messages
+{
+    internal sealed class ValidationResultCache
+    {
+        private CacheRecord _record;
+        private static readonly Lazy<ValidationResultCache> Singleton = new Lazy<ValidationResultCache>(() => new ValidationResultCache());
+
+        private ValidationResultCache()
+        {
+        }
+
+        public static ValidationResultCache Instance => Singleton.Value;
+
+        public bool TryGet(long key, out IReadOnlyCollection<Version.ValidationResult> value)
+        {
+            var record = _record;
+            value = record?.Key == key ? record.Value : null;
+            return value != null;
+        }
+
+        public void Put(long key, IReadOnlyCollection<Version.ValidationResult> value)
+        {
+            _record = new CacheRecord(key, new HashSet<Version.ValidationResult>(value));
+        }
+
+        public void ApplyPatch(IReadOnlyCollection<Version.ValidationResult> added, IReadOnlyCollection<Version.ValidationResult> removed)
+        {
+            var record = _record;
+            var patched = new HashSet<Version.ValidationResult>(record.Value);
+            patched.UnionWith(added);
+            patched.ExceptWith(removed);
+            _record = new CacheRecord(record.Key + 1, patched);
+        }
+
+        private class CacheRecord
+        {
+            public CacheRecord(long key, IReadOnlyCollection<Version.ValidationResult> value)
+            {
+                Key = key;
+                Value = value;
+            }
+
+            public long Key { get; }
+
+            public IReadOnlyCollection<Version.ValidationResult> Value { get; }
+        }
+    }
+}

--- a/ValidationRules.Replication/ValidationResultExtensions.cs
+++ b/ValidationRules.Replication/ValidationResultExtensions.cs
@@ -9,6 +9,7 @@ namespace NuClear.ValidationRules.Replication
     {
         /// <summary>
         /// Проставляет для всех сущностей VersionId
+        /// Применяется последней, копирует все поля.
         /// </summary>
         internal static IEnumerable<Version.ValidationResult> ApplyVersionId(this IEnumerable<Version.ValidationResult> enumerable, long versionId)
             => enumerable.Select(x => new Version.ValidationResult
@@ -24,6 +25,10 @@ namespace NuClear.ValidationRules.Replication
                 Resolved = x.Resolved,
             });
 
+        /// <summary>
+        /// Проставляет для всех сущностей Resolved = true
+        /// Не копирует VersionId, поскольку всешда применяется для сущностей с ещё незаполненным VersionId.
+        /// </summary>
         internal static IEnumerable<Version.ValidationResult> ApplyResolved(this IEnumerable<Version.ValidationResult> enumerable)
             => enumerable.Select(x => new Version.ValidationResult
             {
@@ -40,11 +45,13 @@ namespace NuClear.ValidationRules.Replication
         /// <summary>
         /// Проставляет для всех сущностей MessageTypeId
         /// Не копирует VersionId, поскольку всешда применяется для сущностей с ещё незаполненным VersionId.
+        /// Не копирует Resolved, поскольку всешда применяется для сущностей с ещё незаполненным VersionId.
         /// </summary>
         internal static IQueryable<Version.ValidationResult> ApplyMessageType(this IQueryable<Version.ValidationResult> queryable, int messageTypeId)
             => queryable.Select(x => new Version.ValidationResult
                 {
                     MessageType = messageTypeId,
+
                     MessageParams = x.MessageParams,
                     PeriodEnd = x.PeriodEnd,
                     PeriodStart = x.PeriodStart,

--- a/ValidationRules.Replication/ValidationRules.Replication.csproj
+++ b/ValidationRules.Replication/ValidationRules.Replication.csproj
@@ -221,6 +221,7 @@
     <Compile Include="AdvertisementRules\Validation\OrderPositionMustNotReferenceDeletedAdvertisement.cs" />
     <Compile Include="AdvertisementRules\Validation\OrderPositionAdvertisementMustHaveAdvertisement.cs" />
     <Compile Include="Commands\SyncPeriodCommand.cs" />
+    <Compile Include="Messages\ValidationResultCache.cs" />
     <Compile Include="PriceRules\Aggregates\FirmAggregateRootActor.cs" />
     <Compile Include="PriceRules\Validation\OrderPositionMustCorrespontToActualPrice.cs" />
     <Compile Include="Commands\RecalculatePeriodCommand.cs" />


### PR DESCRIPTION
Сейчас запрос на чтение занимает заметное время, пробую для начала сохранять результаты в памяти процесса, если результат впечатлит - подумаем о том, что у нас крутится несколько процессов.