### PR TITLE
Исправил поведение PropertyProvider для value-objects

### DIFF
--- a/Tests/ValidationRules.Replication.StateInitialization.Tests/Consistency/OrderMustHaveActiveDeal.cs
+++ b/Tests/ValidationRules.Replication.StateInitialization.Tests/Consistency/OrderMustHaveActiveDeal.cs
@@ -82,7 +82,6 @@ namespace NuClear.ValidationRules.Replication.StateInitialization.Tests
                                                                                       bool branchOfficeOrganizationUnit = true,
                                                                                       bool currency = true,
                                                                                       bool deal = true,
-                                                                                      bool inspector = true,
                                                                                       bool legalPerson = true,
                                                                                       bool legalPersonProfile = true)
         {
@@ -92,7 +91,6 @@ namespace NuClear.ValidationRules.Replication.StateInitialization.Tests
                     BranchOfficeOrganizationUnit = branchOfficeOrganizationUnit,
                     Currency = currency,
                     Deal = deal,
-                    Inspector = inspector,
                     LegalPerson = legalPerson,
                     LegalPersonProfile = legalPersonProfile,
                 };

--- a/ValidationRules.Querying.Host/Composition/Composers/OrderRequiredFieldsShouldBeSpecifiedMessageComposer.cs
+++ b/ValidationRules.Querying.Host/Composition/Composers/OrderRequiredFieldsShouldBeSpecifiedMessageComposer.cs
@@ -29,10 +29,6 @@ namespace NuClear.ValidationRules.Querying.Host.Composition.Composers
             {
                 parameters.Add(Resources.BranchOfficeOrganizationUnit);
             }
-            if (dto.Inspector)
-            {
-                parameters.Add(Resources.Inspector);
-            }
             if (dto.Currency)
             {
                 parameters.Add(Resources.Currency);

--- a/ValidationRules.Querying.Host/Composition/ResultExtensions.cs
+++ b/ValidationRules.Querying.Host/Composition/ResultExtensions.cs
@@ -71,7 +71,6 @@ namespace NuClear.ValidationRules.Querying.Host.Composition
                 LegalPerson = bool.Parse(message["legalPerson"]),
                 LegalPersonProfile = bool.Parse(message["legalPersonProfile"]),
                 BranchOfficeOrganizationUnit = bool.Parse(message["legalPerson"]),
-                Inspector = bool.Parse(message["inspector"]),
                 Currency = bool.Parse(message["currency"]),
             };
         }
@@ -142,7 +141,6 @@ namespace NuClear.ValidationRules.Querying.Host.Composition
             public bool LegalPerson { get; set; }
             public bool LegalPersonProfile { get; set; }
             public bool BranchOfficeOrganizationUnit { get; set; }
-            public bool Inspector { get; set; }
             public bool Currency { get; set; }
         }
     }

--- a/ValidationRules.Querying.Host/Properties/Resources.Designer.cs
+++ b/ValidationRules.Querying.Host/Properties/Resources.Designer.cs
@@ -304,15 +304,6 @@ namespace NuClear.ValidationRules.Querying.Host.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Проверяющий.
-        /// </summary>
-        internal static string Inspector {
-            get {
-                return ResourceManager.GetString("Inspector", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Юр. лицо заказчика.
         /// </summary>
         internal static string LegalPerson {

--- a/ValidationRules.Querying.Host/Properties/Resources.resx
+++ b/ValidationRules.Querying.Host/Properties/Resources.resx
@@ -202,9 +202,6 @@
   <data name="InPricePositionOf_Price_ContaiedMoreThanOneAssociatedPositions" xml:space="preserve">
     <value>В Позиции прайс-листа {0} содержится более одной группы сопутствующих позиций, что не поддерживается системой</value>
   </data>
-  <data name="Inspector" xml:space="preserve">
-    <value>Проверяющий</value>
-  </data>
   <data name="LegalPerson" xml:space="preserve">
     <value>Юр. лицо заказчика</value>
   </data>

--- a/ValidationRules.Replication/Accessors/OrderAccessor.cs
+++ b/ValidationRules.Replication/Accessors/OrderAccessor.cs
@@ -43,7 +43,6 @@ namespace NuClear.ValidationRules.Replication.Accessors
                 LegalPersonId = order.LegalPersonId,
                 LegalPersonProfileId = order.LegalPersonProfileId,
                 BranchOfficeOrganizationUnitId = order.BranchOfficeOrganizationUnitId,
-                InspectorId = order.InspectorCode,
                 CurrencyId = order.CurrencyId,
                 BargainId = order.BargainId,
                 DealId = order.DealId,

--- a/ValidationRules.Replication/ConsistencyRules/Aggregates/OrderAggregateRootActor.cs
+++ b/ValidationRules.Replication/ConsistencyRules/Aggregates/OrderAggregateRootActor.cs
@@ -661,13 +661,12 @@ namespace NuClear.ValidationRules.Replication.ConsistencyRules.Aggregates
 
             public IQueryable<Order.MissingRequiredField> GetSource()
                 => from order in _query.For<Facts::Order>()
-                   where !(order.BranchOfficeOrganizationUnitId.HasValue && order.CurrencyId.HasValue && order.InspectorId.HasValue && order.LegalPersonId.HasValue && order.LegalPersonProfileId.HasValue && order.DealId.HasValue)
+                   where !(order.BranchOfficeOrganizationUnitId.HasValue && order.CurrencyId.HasValue && order.LegalPersonId.HasValue && order.LegalPersonProfileId.HasValue && order.DealId.HasValue)
                    select new Order.MissingRequiredField
                        {
                            OrderId = order.Id,
                            BranchOfficeOrganizationUnit = !order.BranchOfficeOrganizationUnitId.HasValue,
                            Currency = !order.CurrencyId.HasValue,
-                           Inspector = !order.InspectorId.HasValue,
                            LegalPerson = !order.LegalPersonId.HasValue,
                            LegalPersonProfile = !order.LegalPersonProfileId.HasValue,
                            Deal = !order.DealId.HasValue,

--- a/ValidationRules.Replication/ConsistencyRules/Validation/OrderRequiredFieldsShouldBeSpecified.cs
+++ b/ValidationRules.Replication/ConsistencyRules/Validation/OrderRequiredFieldsShouldBeSpecified.cs
@@ -25,8 +25,8 @@ namespace NuClear.ValidationRules.Replication.ConsistencyRules.Validation
             var ruleResults =
                 from order in query.For<Order>()
                 from missing in query.For<Order.MissingRequiredField>().Where(x => x.OrderId == order.Id)
-                where missing.Currency || missing.BranchOfficeOrganizationUnit || missing.Inspector
-                      || missing.LegalPerson || missing.LegalPersonProfile
+                where missing.Currency || missing.BranchOfficeOrganizationUnit 
+                    || missing.LegalPerson || missing.LegalPersonProfile
                 select new Version.ValidationResult
                     {
                         MessageParams =
@@ -35,7 +35,6 @@ namespace NuClear.ValidationRules.Replication.ConsistencyRules.Validation
                                         {
                                                 { "currency", missing.Currency },
                                                 { "branchOfficeOrganizationUnit", missing.BranchOfficeOrganizationUnit },
-                                                { "inspector", missing.Inspector },
                                                 { "legalPerson", missing.LegalPerson },
                                                 { "legalPersonProfile", missing.LegalPersonProfile },
                                         },

--- a/ValidationRules.Storage/LinqToDbPropertyProvider.cs
+++ b/ValidationRules.Storage/LinqToDbPropertyProvider.cs
@@ -20,7 +20,8 @@ namespace NuClear.ValidationRules.Storage
 
         public IReadOnlyCollection<PropertyInfo> GetPrimaryKeyProperties<T>()
         {
-            return FindProperties(typeof(T), x => x.IsPrimaryKey);
+            var keyProperties = FindProperties(typeof(T), x => x.IsPrimaryKey);
+            return keyProperties.Any() ? keyProperties : GetProperties<T>();
         }
 
         public IReadOnlyCollection<PropertyInfo> GetProperties<T>()

--- a/ValidationRules.Storage/Model/ConsistencyRules/Aggregates/Order.cs
+++ b/ValidationRules.Storage/Model/ConsistencyRules/Aggregates/Order.cs
@@ -139,7 +139,6 @@ namespace NuClear.ValidationRules.Storage.Model.ConsistencyRules.Aggregates
             public bool LegalPerson { get; set; }
             public bool LegalPersonProfile { get; set; }
             public bool BranchOfficeOrganizationUnit { get; set; }
-            public bool Inspector { get; set; }
             public bool Currency { get; set; }
             public bool Deal { get; set; }
         }

--- a/ValidationRules.Storage/Model/Erm/Order.cs
+++ b/ValidationRules.Storage/Model/Erm/Order.cs
@@ -23,7 +23,6 @@ namespace NuClear.ValidationRules.Storage.Model.Erm
         public long? LegalPersonId { get; set; }
         public long? LegalPersonProfileId { get; set; }
         public long? BranchOfficeOrganizationUnitId { get; set; }
-        public long? InspectorCode { get; set; }
         public long? CurrencyId { get; set; }
         public long? BargainId { get; set; }
         public long? DealId { get; set; }

--- a/ValidationRules.Storage/Model/Facts/Order.cs
+++ b/ValidationRules.Storage/Model/Facts/Order.cs
@@ -17,7 +17,6 @@ namespace NuClear.ValidationRules.Storage.Model.Facts
         public long? LegalPersonId { get; set; }
         public long? LegalPersonProfileId { get; set; }
         public long? BranchOfficeOrganizationUnitId { get; set; }
-        public long? InspectorId { get; set; }
         public long? CurrencyId { get; set; }
         public long? BargainId { get; set; }
         public long? DealId { get; set; }


### PR DESCRIPTION
В River всё было учтено, кроме варианта, что в таблице фактов могут
быть типы без идентификаторов. Думаю, что будет проще всего исправить
это на уровне LinqToDbPropertyProvider.