### PR TITLE
Вынес идентификаторы во временную таблицу

### DIFF
--- a/ValidationRules.Querying.Host/DataAccess/ValidationResultRepositiory.cs
+++ b/ValidationRules.Querying.Host/DataAccess/ValidationResultRepositiory.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 
+using LinqToDB;
+using LinqToDB.Data;
+
 using NuClear.ValidationRules.Storage.Model.Messages;
 using NuClear.ValidationRules.Storage.Specifications;
 
@@ -43,11 +46,12 @@ namespace NuClear.ValidationRules.Querying.Host.DataAccess
         {
             using (var connection = _factory.CreateDataConnection(ConfigurationString))
             {
+                var orderIdentities = ToTemporaryTable(connection, orderIds);
                 var validationResults = connection.GetTable<Version.ValidationResult>()
-                                                  .Where(ForOrdersOrProject(orderIds, projectId))
-                                                  .Where(ForPeriod(start, end))
-                                                  .Where(ForMode(checkModeDescriptor))
-                                                  .ForVersion(versionId);
+                                                    .Where(ForOrdersOrProject(orderIdentities, projectId))
+                                                    .Where(ForPeriod(start, end))
+                                                    .Where(ForMode(checkModeDescriptor))
+                                                    .ForVersion(versionId);
 
                 return validationResults.ToList();
             }
@@ -56,10 +60,22 @@ namespace NuClear.ValidationRules.Querying.Host.DataAccess
         private static Expression<Func<Version.ValidationResult, bool>> ForPeriod(DateTime start, DateTime end)
             => x => x.PeriodStart < end && start < x.PeriodEnd;
 
-        private static Expression<Func<Version.ValidationResult, bool>> ForOrdersOrProject(IReadOnlyCollection<long> orderIds, long? projectId)
-            => x => x.OrderId.HasValue && orderIds.Contains(x.OrderId.Value) || x.ProjectId.HasValue && x.ProjectId == projectId;
+        private static Expression<Func<Version.ValidationResult, bool>> ForOrdersOrProject(ITable<Identity> orderIds, long? projectId)
+            => x => x.OrderId.HasValue && orderIds.Any(y => y.Id == x.OrderId.Value) || x.ProjectId.HasValue && x.ProjectId == projectId;
 
         private static Expression<Func<Version.ValidationResult, bool>> ForMode(ICheckModeDescriptor checkModeDescriptor)
             => x => checkModeDescriptor.Rules.Contains((MessageTypeCode)x.MessageType);
+
+        private static ITable<Identity> ToTemporaryTable(DataConnection connection, IEnumerable<long> ids)
+        {
+            var orderIdentities = connection.CreateTable<Identity>($"#{Guid.NewGuid()}");
+            orderIdentities.BulkCopy(ids.Select(x => new Identity { Id = x }));
+            return orderIdentities;
+        }
+
+        private struct Identity
+        {
+            public long Id { get; set; }
+        }
     }
 }


### PR DESCRIPTION
Замена конструкции "Id in (...)" на "exists(select * from ...)" даёт ощутимое ускорение запроса при большом числе идентификаторов.