### PR TITLE
Исправил сравнение объектов привязки

### DIFF
--- a/Tests/ValidationRules.Replication.Tests/BindingObjectSpecificationTests.cs
+++ b/Tests/ValidationRules.Replication.Tests/BindingObjectSpecificationTests.cs
@@ -34,7 +34,9 @@ namespace NuClear.ValidationRules.Replication.Tests
             var anotherCategory3 = new Parameter { Category3Id = 33, Category1Id = 11 };
             var anotherCategory1 = new Parameter { Category1Id = 11 }; // Не бывает по бизнесу
             var anotherAddressCategory3 = new Parameter { Category3Id = 33, Category1Id = 11, FirmAddressId = 11 };
-            var anotherAddressCategory1 = new Parameter { Category1Id = 11, FirmAddressId = 11 };
+            var another1AddressCategory1 = new Parameter { Category1Id = 11, FirmAddressId = 11 }; // полное отличие
+            var another2AddressCategory1 = new Parameter { Category1Id = 1, FirmAddressId = 11 }; // совпадает рубрика
+            var another3AddressCategory1 = new Parameter { Category1Id = 11, FirmAddressId = 1 }; // совпадает адрес
             var anotherAddress = new Parameter { FirmAddressId = 11 };
 
             return new[]
@@ -55,7 +57,9 @@ namespace NuClear.ValidationRules.Replication.Tests
                     new TestCaseData(category3, anotherCategory3, false),
                     //new TestCaseData(category3, anotherCategory1, false),
                     new TestCaseData(category3, anotherAddressCategory3, false),
-                    new TestCaseData(category3, anotherAddressCategory1, false),
+                    new TestCaseData(category3, another1AddressCategory1, false),
+                    new TestCaseData(category3, another2AddressCategory1, false),
+                    new TestCaseData(category3, another3AddressCategory1, false),
                     new TestCaseData(category3, anotherAddress, false),
 
                     //new TestCaseData(category1, category1, true),
@@ -73,13 +77,17 @@ namespace NuClear.ValidationRules.Replication.Tests
                     new TestCaseData(addressCategory3, address, true),
 
                     new TestCaseData(addressCategory3, anotherAddressCategory3, false),
-                    new TestCaseData(addressCategory3, anotherAddressCategory1, false),
+                    new TestCaseData(addressCategory3, another1AddressCategory1, false),
+                    new TestCaseData(addressCategory3, another2AddressCategory1, false),
+                    new TestCaseData(addressCategory3, another3AddressCategory1, false),
                     new TestCaseData(addressCategory3, anotherAddress, false),
 
                     new TestCaseData(addressCategory1, addressCategory1, true),
                     new TestCaseData(addressCategory1, address, true),
 
-                    new TestCaseData(addressCategory1, anotherAddressCategory1, false),
+                    new TestCaseData(addressCategory1, another1AddressCategory1, false),
+                    new TestCaseData(addressCategory1, another2AddressCategory1, false),
+                    new TestCaseData(addressCategory1, another3AddressCategory1, false),
                     new TestCaseData(addressCategory1, anotherAddress, false),
 
                     new TestCaseData(address, address, true),

--- a/Tests/ValidationRules.Replication.Tests/BindingObjectSpecificationTests.cs
+++ b/Tests/ValidationRules.Replication.Tests/BindingObjectSpecificationTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 
-using NuClear.ValidationRules.Replication.AdvertisementRules.Aggregates;
 using NuClear.ValidationRules.Replication.Specifications;
 using NuClear.ValidationRules.Storage.Model.PriceRules.Aggregates;
 
@@ -10,50 +9,6 @@ using NUnit.Framework;
 
 namespace NuClear.ValidationRules.Replication.Tests
 {
-    public sealed class CouponBeginEndMonthTests
-    {
-        [TestCaseSource(nameof(BeginMonthTestCases))]
-        public void BeginMonthTests(DateTime actual, DateTime expected)
-        {
-            Assert.AreEqual(expected, AdvertisementAggregateRootActor.CouponAccessor.BeginMonth(actual));
-        }
-        private static IEnumerable<TestCaseData> BeginMonthTestCases()
-        {
-            return new[]
-                {
-                    new TestCaseData(Case(27, 01), Case(01, 01)),
-
-                    new TestCaseData(Case(31, 01), Case(01, 02)),
-                    new TestCaseData(Case(01, 02), Case(01, 02)),
-                    new TestCaseData(Case(05, 02), Case(01, 02)),
-                    new TestCaseData(Case(06, 02), Case(01, 02)),
-                    new TestCaseData(Case(24, 02), Case(01, 02)),
-                };
-        }
-
-        [TestCaseSource(nameof(EndMonthTestCases))]
-        public void EndMonthTests(DateTime actual, DateTime expected)
-        {
-            Assert.AreEqual(expected, AdvertisementAggregateRootActor.CouponAccessor.EndMonth(actual));
-        }
-        private static IEnumerable<TestCaseData> EndMonthTestCases()
-        {
-            return new[]
-                {
-                    new TestCaseData(Case(01, 01), Case(01, 01)),
-                    new TestCaseData(Case(04, 01), Case(01, 01)),
-
-                    new TestCaseData(Case(05, 01), Case(01, 02)),
-                    new TestCaseData(Case(31, 01), Case(01, 02)),
-                };
-        }
-
-        private static DateTime Case(int day, int month)
-        {
-            return new DateTime(10, month, day);
-        }
-    }
-
     [TestFixture]
     public sealed class BindingObjectSpecificationTests
     {

--- a/Tests/ValidationRules.Replication.Tests/BindingObjectSpecificationTests.cs
+++ b/Tests/ValidationRules.Replication.Tests/BindingObjectSpecificationTests.cs
@@ -33,7 +33,9 @@ namespace NuClear.ValidationRules.Replication.Tests
 
             var anotherCategory3 = new Parameter { Category3Id = 33, Category1Id = 11 };
             var anotherCategory1 = new Parameter { Category1Id = 11 }; // Не бывает по бизнесу
-            var anotherAddressCategory3 = new Parameter { Category3Id = 33, Category1Id = 11, FirmAddressId = 11 };
+            var another1AddressCategory3 = new Parameter { Category3Id = 33, Category1Id = 11, FirmAddressId = 11 }; // полное отличие
+            var another2AddressCategory3 = new Parameter { Category3Id = 3, Category1Id = 1, FirmAddressId = 11 }; // совпадает рубрика
+            var another3AddressCategory3 = new Parameter { Category3Id = 33, Category1Id = 11, FirmAddressId = 1 }; // совпадает адрес
             var another1AddressCategory1 = new Parameter { Category1Id = 11, FirmAddressId = 11 }; // полное отличие
             var another2AddressCategory1 = new Parameter { Category1Id = 1, FirmAddressId = 11 }; // совпадает рубрика
             var another3AddressCategory1 = new Parameter { Category1Id = 11, FirmAddressId = 1 }; // совпадает адрес
@@ -56,7 +58,9 @@ namespace NuClear.ValidationRules.Replication.Tests
 
                     new TestCaseData(category3, anotherCategory3, false),
                     //new TestCaseData(category3, anotherCategory1, false),
-                    new TestCaseData(category3, anotherAddressCategory3, false),
+                    new TestCaseData(category3, another1AddressCategory3, false),
+                    new TestCaseData(category3, another2AddressCategory3, true),
+                    new TestCaseData(category3, another3AddressCategory3, false),
                     new TestCaseData(category3, another1AddressCategory1, false),
                     new TestCaseData(category3, another2AddressCategory1, false),
                     new TestCaseData(category3, another3AddressCategory1, false),
@@ -76,7 +80,9 @@ namespace NuClear.ValidationRules.Replication.Tests
                     new TestCaseData(addressCategory3, addressCategory1, false),
                     new TestCaseData(addressCategory3, address, true),
 
-                    new TestCaseData(addressCategory3, anotherAddressCategory3, false),
+                    new TestCaseData(addressCategory3, another1AddressCategory3, false),
+                    new TestCaseData(addressCategory3, another2AddressCategory3, false),
+                    new TestCaseData(addressCategory3, another3AddressCategory3, false),
                     new TestCaseData(addressCategory3, another1AddressCategory1, false),
                     new TestCaseData(addressCategory3, another2AddressCategory1, false),
                     new TestCaseData(addressCategory3, another3AddressCategory1, false),

--- a/Tests/ValidationRules.Replication.Tests/CouponBeginEndMonthTests.cs
+++ b/Tests/ValidationRules.Replication.Tests/CouponBeginEndMonthTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+
+using NuClear.ValidationRules.Replication.AdvertisementRules.Aggregates;
+
+using NUnit.Framework;
+
+namespace NuClear.ValidationRules.Replication.Tests
+{
+    public sealed class CouponBeginEndMonthTests
+    {
+        [TestCaseSource(nameof(BeginMonthTestCases))]
+        public void BeginMonthTests(DateTime actual, DateTime expected)
+        {
+            Assert.AreEqual(expected, AdvertisementAggregateRootActor.CouponAccessor.BeginMonth(actual));
+        }
+        private static IEnumerable<TestCaseData> BeginMonthTestCases()
+        {
+            return new[]
+                {
+                    new TestCaseData(Case(27, 01), Case(01, 01)),
+
+                    new TestCaseData(Case(31, 01), Case(01, 02)),
+                    new TestCaseData(Case(01, 02), Case(01, 02)),
+                    new TestCaseData(Case(05, 02), Case(01, 02)),
+                    new TestCaseData(Case(06, 02), Case(01, 02)),
+                    new TestCaseData(Case(24, 02), Case(01, 02)),
+                };
+        }
+
+        [TestCaseSource(nameof(EndMonthTestCases))]
+        public void EndMonthTests(DateTime actual, DateTime expected)
+        {
+            Assert.AreEqual(expected, AdvertisementAggregateRootActor.CouponAccessor.EndMonth(actual));
+        }
+        private static IEnumerable<TestCaseData> EndMonthTestCases()
+        {
+            return new[]
+                {
+                    new TestCaseData(Case(01, 01), Case(01, 01)),
+                    new TestCaseData(Case(04, 01), Case(01, 01)),
+
+                    new TestCaseData(Case(05, 01), Case(01, 02)),
+                    new TestCaseData(Case(31, 01), Case(01, 02)),
+                };
+        }
+
+        private static DateTime Case(int day, int month)
+        {
+            return new DateTime(10, month, day);
+        }
+    }
+}

--- a/Tests/ValidationRules.Replication.Tests/ValidationRules.Replication.Tests.csproj
+++ b/Tests/ValidationRules.Replication.Tests/ValidationRules.Replication.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -190,6 +190,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BindingObjectSpecificationTests.cs" />
+    <Compile Include="CouponBeginEndMonthTests.cs" />
     <Compile Include="DataFixtureBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/ValidationRules.Replication/Specifications/Specs.Join.Aggs.cs
+++ b/ValidationRules.Replication/Specifications/Specs.Join.Aggs.cs
@@ -99,7 +99,7 @@ namespace NuClear.ValidationRules.Replication.Specifications
                                                     (position.FirmAddressId == null || binding.FirmAddressId == null)) ||
                                                    ((position.Category1Id == null ||
                                                      binding.Category1Id == null ||
-                                                     position.Category3Id == binding.Category3Id ||
+                                                     position.Category3Id == binding.Category3Id && position.Category3Id != null && binding.Category3Id != null ||
                                                      position.Category1Id == binding.Category1Id && position.Category3Id == null && binding.Category3Id == null) &&
                                                     position.FirmAddressId == binding.FirmAddressId));
                 }


### PR DESCRIPTION
Случай, когда у рубрики первого уровня адреса совпадают адреса, но отличаются рубрики был не покрыт тестами и содержал ошибку.