### PR TITLE
Исправил пересчёт NomenclatureCategory

### DIFF
--- a/ValidationRules.OperationsProcessing/EntityTypeMap.Facts.cs
+++ b/ValidationRules.OperationsProcessing/EntityTypeMap.Facts.cs
@@ -46,9 +46,9 @@ namespace NuClear.ValidationRules.OperationsProcessing
             .AddMapping<EntityTypeOrderFile>(typeof(Facts::OrderScanFile))
             .AddMapping<EntityTypePosition>(typeof(Facts::Position),
                                             typeof(Facts::PositionChild))
-            .AddMapping<EntityTypePrice>(typeof(Facts::Price))
-            .AddMapping<EntityTypePricePosition>(typeof(Facts::PricePosition),
-                                                 typeof(Facts::NomenclatureCategory))
+            .AddMapping<EntityTypePrice>(typeof(Facts::Price),
+                                         typeof(Facts::NomenclatureCategory))
+            .AddMapping<EntityTypePricePosition>(typeof(Facts::PricePosition))
             .AddMapping<EntityTypeProject>(typeof(Facts::Project),
                                            typeof(Facts::CostPerClickCategoryRestriction),
                                            typeof(Facts::SalesModelCategoryRestriction))


### PR DESCRIPTION
Во-первых, в ней для пересчёта используется идентификатор прайс-листа.
На самом деле, эта сущность - одно из дурнопахнущих решений, выбранное
исходя из условий максимального повторения логики erm и нежелания начинать
слушать поток flowNomenclatures.NomenclatureCategory (и потоки вовсе).

Но изменение позиций прайс-листа в этом случае не интересно совсем:
нельзя менять позиции опубликованного прайс-листа, а неопубликованный
ни на что у нас не влияет. Поэтому достаточно обрабатывать публикацию и
распубликацию прайс-листов, и это вторая причина завязать их на события
прайс-листа.