### PR TITLE
Исправил ошибку в балансах ЛС

### DIFF
--- a/Tests/ValidationRules.Replication.StateInitialization.Tests/Account/AccountBalanceShouldBePositive.cs
+++ b/Tests/ValidationRules.Replication.StateInitialization.Tests/Account/AccountBalanceShouldBePositive.cs
@@ -20,6 +20,7 @@ namespace NuClear.ValidationRules.Replication.StateInitialization.Tests
                 .Name(nameof(AccountBalanceShouldBePositive))
                 .Fact(
                     new Facts::Account { Id = 1, Balance = 11, BranchOfficeOrganizationUnitId = 1, LegalPersonId = 2 },
+                    new Facts::Account { Id = 2, Balance = 0, BranchOfficeOrganizationUnitId = 3, LegalPersonId = 4 },
 
                     new Facts::Order { Id = 1, BranchOfficeOrganizationUnitId = 1, LegalPersonId = 2, BeginDistribution = FirstDayJan, EndDistributionFact = FirstDayMar, WorkflowStep = 4 },
                     new Facts::OrderPosition { Id = 2, OrderId = 1 },
@@ -40,9 +41,9 @@ namespace NuClear.ValidationRules.Replication.StateInitialization.Tests
                     new Facts::ReleaseWithdrawal { OrderPositionId = 4, Amount = 0, Start = FirstDayFeb },
                     new Facts::Lock { Id = 3, OrderId = 3, AccountId = 1, Start = FirstDayJan, Amount = 0 },
 
-                    new Facts::Order { Id = 4, BranchOfficeOrganizationUnitId = 1, LegalPersonId = 2, BeginDistribution = FirstDayJan, EndDistributionFact = FirstDayMar, WorkflowStep = 4 },
+                    new Facts::Order { Id = 4, BranchOfficeOrganizationUnitId = 3, LegalPersonId = 4, BeginDistribution = FirstDayJan, EndDistributionFact = FirstDayMar, WorkflowStep = 4 },
                     new Facts::OrderPosition { Id = 5, OrderId = 4 },
-                    new Facts::ReleaseWithdrawal { OrderPositionId = 5, Amount = 1000, Start = FirstDayMar },
+                    new Facts::ReleaseWithdrawal { OrderPositionId = 5, Amount = 1000, Start = FirstDayApr },
 
                     new Facts::Project())
                 .Aggregate(
@@ -50,9 +51,9 @@ namespace NuClear.ValidationRules.Replication.StateInitialization.Tests
                     new Aggregates::Order { Id = 2, AccountId = 1, BeginDistributionDate = FirstDayJan, EndDistributionDate = FirstDayMar },
                     new Aggregates::Order.DebtPermission { OrderId = 2, Start = FirstDayFeb, End = FirstDayMar },
                     new Aggregates::Order { Id = 3, AccountId = 1, BeginDistributionDate = FirstDayJan, EndDistributionDate = FirstDayMar, IsFreeOfCharge = true },
+                    new Aggregates::Order { Id = 4, AccountId = 2, BeginDistributionDate = FirstDayJan, EndDistributionDate = FirstDayMar },
                     new Aggregates::Account.AccountPeriod { AccountId = 1, Balance = 11, LockedAmount = 11, OwerallLockedAmount = 11, ReleaseAmount = 11, Start = FirstDayJan, End = FirstDayFeb },
-                    new Aggregates::Account.AccountPeriod { AccountId = 1, Balance = 11, LockedAmount = 0, OwerallLockedAmount = 11, ReleaseAmount = 12, Start = FirstDayFeb, End = FirstDayMar },
-                    new Aggregates::Order { Id = 4, AccountId = 1, BeginDistributionDate = FirstDayJan, EndDistributionDate = FirstDayMar }
+                    new Aggregates::Account.AccountPeriod { AccountId = 1, Balance = 11, LockedAmount = 0, OwerallLockedAmount = 11, ReleaseAmount = 12, Start = FirstDayFeb, End = FirstDayMar }
                     )
                 .Message(
                     new Messages::Version.ValidationResult

--- a/Tests/ValidationRules.Replication.StateInitialization.Tests/Account/AccountBalanceShouldBePositive.cs
+++ b/Tests/ValidationRules.Replication.StateInitialization.Tests/Account/AccountBalanceShouldBePositive.cs
@@ -40,6 +40,10 @@ namespace NuClear.ValidationRules.Replication.StateInitialization.Tests
                     new Facts::ReleaseWithdrawal { OrderPositionId = 4, Amount = 0, Start = FirstDayFeb },
                     new Facts::Lock { Id = 3, OrderId = 3, AccountId = 1, Start = FirstDayJan, Amount = 0 },
 
+                    new Facts::Order { Id = 4, BranchOfficeOrganizationUnitId = 1, LegalPersonId = 2, BeginDistribution = FirstDayJan, EndDistributionFact = FirstDayMar, WorkflowStep = 4 },
+                    new Facts::OrderPosition { Id = 5, OrderId = 4 },
+                    new Facts::ReleaseWithdrawal { OrderPositionId = 5, Amount = 1000, Start = FirstDayMar },
+
                     new Facts::Project())
                 .Aggregate(
                     new Aggregates::Order { Id = 1, AccountId = 1, BeginDistributionDate = FirstDayJan, EndDistributionDate = FirstDayMar },
@@ -47,7 +51,9 @@ namespace NuClear.ValidationRules.Replication.StateInitialization.Tests
                     new Aggregates::Order.DebtPermission { OrderId = 2, Start = FirstDayFeb, End = FirstDayMar },
                     new Aggregates::Order { Id = 3, AccountId = 1, BeginDistributionDate = FirstDayJan, EndDistributionDate = FirstDayMar, IsFreeOfCharge = true },
                     new Aggregates::Account.AccountPeriod { AccountId = 1, Balance = 11, LockedAmount = 11, OwerallLockedAmount = 11, ReleaseAmount = 11, Start = FirstDayJan, End = FirstDayFeb },
-                    new Aggregates::Account.AccountPeriod { AccountId = 1, Balance = 11, LockedAmount = 0, OwerallLockedAmount = 11, ReleaseAmount = 12, Start = FirstDayFeb, End = FirstDayMar })
+                    new Aggregates::Account.AccountPeriod { AccountId = 1, Balance = 11, LockedAmount = 0, OwerallLockedAmount = 11, ReleaseAmount = 12, Start = FirstDayFeb, End = FirstDayMar },
+                    new Aggregates::Order { Id = 4, AccountId = 1, BeginDistributionDate = FirstDayJan, EndDistributionDate = FirstDayMar }
+                    )
                 .Message(
                     new Messages::Version.ValidationResult
                         {

--- a/ValidationRules.Storage/Schema.Facts.cs
+++ b/ValidationRules.Storage/Schema.Facts.cs
@@ -170,8 +170,7 @@ namespace NuClear.ValidationRules.Storage
             builder.Entity<ReleaseWithdrawal>()
                    .HasSchemaName(FactsSchema)
                    .HasPrimaryKey(x => x.OrderPositionId)
-                   .HasPrimaryKey(x => x.Start)
-                   .HasIndex(x => new { x.OrderPositionId }, x => new { x.Amount });
+                   .HasPrimaryKey(x => x.Start);
             builder.Entity<RulesetRule>()
                    .HasSchemaName(FactsSchema)
                    .HasPrimaryKey(x => x.RuleType)


### PR DESCRIPTION
ReleaseWithdrawal - это планируемые списания, ключевое слово "планируемые".
Если заказ расторгнут досрочно (plan<>fact), то мы не должны учитывать списания, которые идут сверх времени фактического размещения заказа.

sql запрос стал чётко попадать в primary key, поэтому нужды в доп. индексе для ReleaseWithdrawal я не вижу.