### PR TITLE
Исправил ошибку в единичной проверке

### DIFF
--- a/ValidationRules.SingleCheck/Store/SchemaManager.cs
+++ b/ValidationRules.SingleCheck/Store/SchemaManager.cs
@@ -24,7 +24,7 @@ namespace NuClear.ValidationRules.SingleCheck.Store
 
         public MappingSchema GetSchema(Lock @lock)
         {
-            var schema = new MappingSchema(_baseSchema);
+            var schema = new MappingSchema(@lock.Id.ToString(), _baseSchema);
             var builder = schema.GetFluentMappingBuilder();
             foreach (var dataObjectType in _dataObjectTypes)
             {


### PR DESCRIPTION
Причиной оказалось кеширование, которое направляло запросы на таблицы не в той схеме.
Указание имени конфигурации помогает библиотеке понять, что запросы всё-такие разные.