### PR TITLE
DefaultDistinctor теперь учитывает поле Extra

### DIFF
--- a/ValidationRules.Querying.Host/Composition/ValidationResultFactory.cs
+++ b/ValidationRules.Querying.Host/Composition/ValidationResultFactory.cs
@@ -110,10 +110,13 @@ namespace NuClear.ValidationRules.Querying.Host.Composition
 
             bool IEqualityComparer<Message>.Equals(Message x, Message y)
                 => x.References.Count == y.References.Count
-                   && x.References.Zip(y.References, (l, r) => Reference.Comparer.Equals(l, r)).All(equal => equal);
+                   && x.References.SequenceEqual(y.References, Reference.Comparer)
+                   && x.Extra.Count == y.Extra.Count
+                   && x.Extra.All(pair => y.Extra.TryGetValue(pair.Key, out var value) && pair.Value == value);
 
             int IEqualityComparer<Message>.GetHashCode(Message obj)
-                => obj.References.Aggregate(0, (accum, reference) => (accum * 367) ^ Reference.Comparer.GetHashCode(reference));
+                => obj.References.Aggregate(0, (accum, reference) => (accum * 397) ^ Reference.Comparer.GetHashCode(reference)) ^
+                   obj.Extra.Aggregate(0, (accum, pair) => (accum * 397) ^ (pair.Key.GetHashCode() * 397) ^ pair.Value.GetHashCode());
         }
     }
 }

--- a/ValidationRules.Storage/Model/Messages/Reference.cs
+++ b/ValidationRules.Storage/Model/Messages/Reference.cs
@@ -30,7 +30,7 @@ namespace NuClear.ValidationRules.Storage.Model.Messages
         private class ReferenceComparer : IEqualityComparer<Reference>
         {
             public bool Equals(Reference x, Reference y)
-                => x.EntityType == y.EntityType && x.Id == y.Id && x.Children.Count == y.Children.Count && x.Children.Zip(y.Children, (l, r) => Equals(l, r)).All(equal => equal);
+                => x.EntityType == y.EntityType && x.Id == y.Id && x.Children.Count == y.Children.Count && x.Children.SequenceEqual(y.Children, this);
 
             public int GetHashCode(Reference obj)
                 => obj.Id.GetHashCode() ^ obj.EntityType;


### PR DESCRIPTION
Нельзя сказать что два Message равны если поля Extra у них разные.

Это проявилось в сравнении рекламной и контактной ссылки, когда всё References одинаковые, а Extra["website"] разные - сообщения схлапывались в одно, хотя не должны.