### PR TITLE
Сделал правило привязки рубрик к городу таким же как в ERM

### DIFF
--- a/Tests/ValidationRules.Replication.Comparison.Tests/RiverService/RiverToErmMappingExtensions.cs
+++ b/Tests/ValidationRules.Replication.Comparison.Tests/RiverService/RiverToErmMappingExtensions.cs
@@ -59,7 +59,7 @@ namespace ValidationRules.Replication.Comparison.Tests.RiverService
                             { MessageTypeCode.WhiteListAdvertisementMustPresent, 21 },
                             { MessageTypeCode.WhiteListAdvertisementMayPresent, 21 },
                             { MessageTypeCode.ProjectMustContainCostPerClickMinimumRestriction, 49 },
-                            { MessageTypeCode.OrderMustUseCategoriesOnlyAvailableInProject, 7 },
+                            { MessageTypeCode.OrderMustUseCategoriesOnlyAvailableInProject, 8 },
                             { MessageTypeCode.OrderMustNotIncludeReleasedPeriod, 17 },
                             { MessageTypeCode.OrderPositionCostPerClickMustNotBeLessMinimum, 48 },
                             { MessageTypeCode.FirmAddressMustBeLocatedOnTheMap, 34 },

--- a/ValidationRules.Querying.Host/Composition/Composers/OrderMustUseCategoriesOnlyAvailableInProjectMessageComposer.cs
+++ b/ValidationRules.Querying.Host/Composition/Composers/OrderMustUseCategoriesOnlyAvailableInProjectMessageComposer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 using NuClear.ValidationRules.Querying.Host.Properties;
 using NuClear.ValidationRules.Storage.Identitites.EntityTypes;
@@ -6,21 +7,51 @@ using NuClear.ValidationRules.Storage.Model.Messages;
 
 namespace NuClear.ValidationRules.Querying.Host.Composition.Composers
 {
-    public sealed class OrderMustUseCategoriesOnlyAvailableInProjectMessageComposer : IMessageComposer
+    public sealed class OrderMustUseCategoriesOnlyAvailableInProjectMessageComposer : IMessageComposer, IDistinctor
     {
         public MessageTypeCode MessageType => MessageTypeCode.OrderMustUseCategoriesOnlyAvailableInProject;
 
         public MessageComposerResult Compose(NamedReference[] references, IReadOnlyDictionary<string, string> extra)
         {
             var orderReference = references.Get<EntityTypeOrder>();
-            var categoryReference = references.Get<EntityTypeCategory>();
             var orderPositionReference = references.Get<EntityTypeOrderPosition>();
+            // todo: сортировки нет в требованиях, сделана для соответствия erm
+            var categoryReferences = references.GetMany<EntityTypeCategory>().OrderBy(x => x.Name);
 
             return new MessageComposerResult(
                 orderReference,
-                Resources.OrdersCheckOrderPositionContainsCategoriesFromWrongOrganizationUnit,
-                categoryReference,
-                orderPositionReference);
+                string.Format(Resources.OrderCheckOrderPositionContainsCategoriesFromWrongOrganizationUnit, string.Join(", ", categoryReferences.Select((x, i) => "{" + (i + 1) + "}"))),
+                new []{ orderPositionReference }.Concat(categoryReferences).ToArray());
+        }
+
+        public IEnumerable<Message> Distinct(IEnumerable<Message> messages)
+        {
+            return messages.GroupBy(x =>
+            {
+                var opaReference = x.References.Get<EntityTypeOrderPositionAdvertisement>();
+
+                return new
+                {
+                    x.OrderId,
+                    x.MessageType,
+                    x.ProjectId,
+                    OrderPositionId = opaReference.Children.Get<EntityTypeOrderPosition>().Id,
+                    PositionId = opaReference.Children.Get<EntityTypePosition>().Id
+                };
+            }, x => x.References)
+            .Select(x => new Message
+            {
+                OrderId = x.Key.OrderId,
+                MessageType = x.Key.MessageType,
+                ProjectId = x.Key.ProjectId,
+                References = new List<Reference>(x.SelectMany(ReferenceExtensions.GetMany<EntityTypeCategory>))
+                {
+                    new Reference(EntityTypeOrder.Instance.Id, x.Key.OrderId.Value),
+                    new Reference(EntityTypeOrderPositionAdvertisement.Instance.Id, 0,
+                                    new Reference(EntityTypeOrderPosition.Instance.Id, x.Key.OrderPositionId),
+                                    new Reference(EntityTypePosition.Instance.Id, x.Key.PositionId))
+                }
+            });
         }
     }
 }

--- a/ValidationRules.Querying.Host/Properties/Resources.Designer.cs
+++ b/ValidationRules.Querying.Host/Properties/Resources.Designer.cs
@@ -439,6 +439,15 @@ namespace NuClear.ValidationRules.Querying.Host.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to В позиции {{0}} задействованы рубрики, не привязанные к отделению организации города назначения заказа: {0}.
+        /// </summary>
+        internal static string OrderCheckOrderPositionContainsCategoriesFromWrongOrganizationUnit {
+            get {
+                return ResourceManager.GetString("OrderCheckOrderPositionContainsCategoriesFromWrongOrganizationUnit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Позиция {0} соответствует скрытой позиции прайс листа. Необходимо указать активную позицию из текущего действующего прайс-листа..
         /// </summary>
         internal static string OrderCheckOrderPositionCorrespontToInactivePosition {
@@ -624,15 +633,6 @@ namespace NuClear.ValidationRules.Querying.Host.Properties {
         internal static string OrdersCheckOrderInsufficientFunds {
             get {
                 return ResourceManager.GetString("OrdersCheckOrderInsufficientFunds", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Рубрика {0} используется в позиции {1}, но не привязана к отделению организации города назначения заказа.
-        /// </summary>
-        internal static string OrdersCheckOrderPositionContainsCategoriesFromWrongOrganizationUnit {
-            get {
-                return ResourceManager.GetString("OrdersCheckOrderPositionContainsCategoriesFromWrongOrganizationUnit", resourceCulture);
             }
         }
         

--- a/ValidationRules.Querying.Host/Properties/Resources.resx
+++ b/ValidationRules.Querying.Host/Properties/Resources.resx
@@ -309,8 +309,8 @@
   <data name="OrdersCheckOrderInsufficientFunds" xml:space="preserve">
     <value>Для оформления заказа недостаточно средств. Необходимо: {0}. Имеется: {1}.</value>
   </data>
-  <data name="OrdersCheckOrderPositionContainsCategoriesFromWrongOrganizationUnit" xml:space="preserve">
-    <value>Рубрика {0} используется в позиции {1}, но не привязана к отделению организации города назначения заказа</value>
+  <data name="OrderCheckOrderPositionContainsCategoriesFromWrongOrganizationUnit" xml:space="preserve">
+    <value>В позиции {{0}} задействованы рубрики, не привязанные к отделению организации города назначения заказа: {0}</value>
   </data>
   <data name="OrdersCheckPositionMustHaveAdvertisementElements" xml:space="preserve">
     <value>В рекламном материале {0} не заполнен обязательный элемент {1}</value>

--- a/ValidationRules.Replication/ProjectRules/Validation/OrderMustUseCategoriesOnlyAvailableInProject.cs
+++ b/ValidationRules.Replication/ProjectRules/Validation/OrderMustUseCategoriesOnlyAvailableInProject.cs
@@ -10,12 +10,10 @@ namespace NuClear.ValidationRules.Replication.ProjectRules.Validation
     /// <summary>
     /// Для заказов, у которых в объектах привязки встречаются не привязные к городу назначения рубрики, должна выводиться ошибка.
     /// "В позиции {0} задействованы рубрики, не привязанные к отделению организации города назначения заказа: {рубрики}"
-    /// -> "Рубрика {0} используется в позиции {1}, но не привязана к отделению организации города назначения заказа"
     /// 
     /// Source: CategoriesLinkedToDestOrgUnitOrderValidationRule
     /// 
     /// * Рубрика первого уровня считается привязанной к городу, если првязана хотя бы одна из её дочерних.
-    /// * Сделано изменение относительно ERM - в одном сообщении только одна рубрика
     /// </summary>
     public sealed class OrderMustUseCategoriesOnlyAvailableInProject : ValidationResultAccessorBase
     {
@@ -34,7 +32,6 @@ namespace NuClear.ValidationRules.Replication.ProjectRules.Validation
                     {
                         MessageParams =
                             new MessageParams(
-                                    new Reference<EntityTypeOrder>(order.Id),
                                     new Reference<EntityTypeOrderPositionAdvertisement>(0,
                                         new Reference<EntityTypeOrderPosition>(opa.OrderPositionId),
                                         new Reference<EntityTypePosition>(opa.PositionId)),


### PR DESCRIPTION
У нас в метаданных вообще стоял не тот код проверки (7 вместо 8), и мы сравнивали хз что с чем. Сейчас вроде то что надо. Сделал по аналогии с проверкой на купоны.