### PR TITLE
Актуализировал проверку адреса фирмы

### DIFF
--- a/Tests/ValidationRules.Replication.StateInitialization.Tests/Consistency/LinkedFirmAddressShouldBeValid.cs
+++ b/Tests/ValidationRules.Replication.StateInitialization.Tests/Consistency/LinkedFirmAddressShouldBeValid.cs
@@ -32,7 +32,9 @@ namespace NuClear.ValidationRules.Replication.StateInitialization.Tests
                     new Facts::FirmAddress { Id = 3, FirmId = 1, IsActive = false },
 
                     new Facts::OrderPositionAdvertisement { Id = 4, OrderPositionId = 1, FirmAddressId = 4, PositionId = 1 },
-                    new Facts::FirmAddress { Id = 4, FirmId = 1, IsActive = true, IsClosedForAscertainment = true })
+                    new Facts::FirmAddress { Id = 4, FirmId = 1, IsActive = true, IsClosedForAscertainment = true },
+
+                    new Facts::Position {Id = 1})
                 .Aggregate(
                     new Aggregates::Order { Id = 1, BeginDistribution = MonthStart(1), EndDistributionPlan = MonthStart(2) },
                     new Aggregates::Order.InvalidFirmAddress { OrderId = 1, FirmAddressId = 1, OrderPositionId = 1, PositionId = 1, State = Aggregates::InvalidFirmAddressState.NotBelongToFirm },

--- a/ValidationRules.Replication/ConsistencyRules/Aggregates/OrderAggregateRootActor.cs
+++ b/ValidationRules.Replication/ConsistencyRules/Aggregates/OrderAggregateRootActor.cs
@@ -131,8 +131,10 @@ namespace NuClear.ValidationRules.Replication.ConsistencyRules.Aggregates
                 => from order in _query.For<Facts::Order>()
                    from orderPosition in _query.For<Facts::OrderPosition>().Where(x => x.OrderId == order.Id)
                    from opa in _query.For<Facts::OrderPositionAdvertisement>().Where(x => x.OrderPositionId == orderPosition.Id)
+                   from position in _query.For<Facts::Position>().Where(x => x.Id == opa.PositionId)
                    from address in _query.For<Facts::FirmAddress>().Where(x => x.Id == opa.FirmAddressId)
-                   let state = address.FirmId != order.FirmId ? InvalidFirmAddressState.NotBelongToFirm
+                   let isFirmMismatchAllowed = Facts.Position.CategoryCodesAllowFirmMismatch.Contains(position.CategoryCode) && position.BindingObjectType == Facts.Position.BindingObjectTypeAddressMultiple
+                   let state = address.FirmId != order.FirmId && !isFirmMismatchAllowed ? InvalidFirmAddressState.NotBelongToFirm
                                 : address.IsDeleted ? InvalidFirmAddressState.Deleted
                                 : !address.IsActive ? InvalidFirmAddressState.NotActive
                                 : address.IsClosedForAscertainment ? InvalidFirmAddressState.ClosedForAscertainment

--- a/ValidationRules.Storage/Model/Facts/Position.cs
+++ b/ValidationRules.Storage/Model/Facts/Position.cs
@@ -9,6 +9,7 @@ namespace NuClear.ValidationRules.Storage.Model.Facts
         public const long CategoryCodeAdvertisementInCategory = 38; // Объявление в рубрике(Объявление под списком выдачи)
 
         public const int BindingObjectTypeCategoryMultipleAsterix = 1;
+        public const int BindingObjectTypeAddressMultiple = 35;
 
         public const int PlatformIndependent = 0;
         public const int PlatformDesktop = 1;
@@ -22,6 +23,16 @@ namespace NuClear.ValidationRules.Storage.Model.Facts
                 26, // Комментарий к адресу
             };
 
+        /// <summary>
+        /// Категории номенклатуры, для которых допускается несовпадение фирмы заказа и фирмы адреса привязки (продажи в чужие карточки)
+        /// </summary>
+        public static readonly IReadOnlyCollection<long> CategoryCodesAllowFirmMismatch = new long[]
+            {
+                809065011136692320, // Реклама в профилях партнеров (партнеры)
+                809065011136692321, // Реклама в профилях партнеров (приоритетное размещение)
+                809065011136692326, // Реклама в профилях партнеров (адрес)
+            };
+
         public long Id { get; set; }
 
         public long? AdvertisementTemplateId { get; set; }
@@ -29,6 +40,7 @@ namespace NuClear.ValidationRules.Storage.Model.Facts
         public int SalesModel { get; set; }
         public int PositionsGroup { get; set; }
 
+        public bool IsFirmMismatchAllowed { get; set; }
 
         public bool IsCompositionOptional { get; set; }
         public bool IsControlledByAmount { get; set; }


### PR DESCRIPTION
При реализации ЗМК разрешили привязывать адреса фирм, не принадлежащие
фирме заказа. Но это действует только для трёх категорий номенклатуры
при обязательном типе объекта привязки "адрес множественный" (по коду).