### PR TITLE
Исправил таймаут на заказах с большим числом РМ

### DIFF
--- a/ValidationRules.SingleCheck/Extensions.cs
+++ b/ValidationRules.SingleCheck/Extensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace NuClear.ValidationRules.SingleCheck
 {
@@ -6,7 +7,14 @@ namespace NuClear.ValidationRules.SingleCheck
     {
         public static T[] Execute<T>(this IQueryable<T> queryable, string name = null)
         {
-            return queryable.ToArray();
+            try
+            {
+                return queryable.ToArray();
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Exception while querying for {typeof(T).FullName}\n{queryable}", ex);
+            }
         }
     }
 }

--- a/ValidationRules.SingleCheck/Store/ErmDataLoader.cs
+++ b/ValidationRules.SingleCheck/Store/ErmDataLoader.cs
@@ -232,8 +232,8 @@ namespace NuClear.ValidationRules.SingleCheck.Store
             store.AddRange(salesModelCategoryRestrictions);
 
             //
-            var advertisements = query.GetTable<Advertisement>()
-                                      .Where(x => firmIds.Contains(x.FirmId.Value) || adverisementIds.Contains(x.Id))
+            var advertisements = query.GetTable<Advertisement>().Where(x => firmIds.Contains(x.FirmId.Value))
+                                      .Union(query.GetTable<Advertisement>().Where(x => adverisementIds.Contains(x.Id)))
                                       .Execute();
             store.AddRange(advertisements);
             var advertisementIds = advertisements.Select(x => x.Id).ToList();


### PR DESCRIPTION
Для запроса вида select * from ... where Foo in (...) OR Bar in ({> 700 ids})
подцеплялся план выполнения с не подходящим для него индексом и в итоге запрос
выполнялся около полутора минут при том, что при малых массивах использовался
другой план, дающий адекватное время выполнения.