### PR TITLE
Исправил ERROR_FILE_IN_USE для файла librdkafka.dll при деплое web app

### DIFF
--- a/ValidationRules.Querying.Host/App_Start/LibRdKafkaLoader.cs
+++ b/ValidationRules.Querying.Host/App_Start/LibRdKafkaLoader.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.ComponentModel;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace NuClear.ValidationRules.Querying.Host
+{
+    // Handle IIS start/stop logic, this class not needed in .net core
+    internal static class LibRdKafkaLoader
+    {
+        private const string DllName = "librdkafka.dll";
+
+        private enum LoadLibraryFlags : uint
+        {
+            // ReSharper disable once InconsistentNaming
+            LOAD_WITH_ALTERED_SEARCH_PATH = 0x00000008
+        }
+
+        [DllImport("kernel32", SetLastError = true)]
+        private static extern IntPtr LoadLibraryEx(string lpFileName, IntPtr hReservedNull, LoadLibraryFlags dwFlags);
+
+        [DllImport("kernel32")]
+        private static extern bool FreeLibrary(IntPtr hModule);
+
+        private static IntPtr _librdkafkaHandle;
+
+        public static void LoadLibrary()
+        {
+            var baseUri = new Uri(Assembly.GetExecutingAssembly().GetName().EscapedCodeBase);
+            var baseDirectory = Path.GetDirectoryName(baseUri.LocalPath);
+            // ReSharper disable once AssignNullToNotNullAttribute
+            var dllDirectory = Path.Combine(baseDirectory, Environment.Is64BitProcess ? "x64" : "x86");
+
+            _librdkafkaHandle = LoadLibraryEx(Path.Combine(dllDirectory, DllName), IntPtr.Zero, LoadLibraryFlags.LOAD_WITH_ALTERED_SEARCH_PATH);
+            if (_librdkafkaHandle == IntPtr.Zero)
+            {
+                var lastError = new Win32Exception();
+                throw new InvalidOperationException($"Error while loading {DllName} or its dependencies from {dllDirectory}", lastError);
+            }
+        }
+
+        public static void FreeLibrary()
+        {
+            if (_librdkafkaHandle != IntPtr.Zero)
+            {
+                // call method twice to unload correctly
+                // 1 reference from LoadLibraryEx and 1 reference from DllImport (in confluent.kafka.dll)
+                FreeLibrary(_librdkafkaHandle);
+                FreeLibrary(_librdkafkaHandle);
+            }
+        }
+    }
+}

--- a/ValidationRules.Querying.Host/App_Start/LibRdKafkaLoader.cs
+++ b/ValidationRules.Querying.Host/App_Start/LibRdKafkaLoader.cs
@@ -13,8 +13,7 @@ namespace NuClear.ValidationRules.Querying.Host
 
         private enum LoadLibraryFlags : uint
         {
-            // ReSharper disable once InconsistentNaming
-            LOAD_WITH_ALTERED_SEARCH_PATH = 0x00000008
+            LoadWithAlteredSearchPath = 8
         }
 
         [DllImport("kernel32", SetLastError = true)]
@@ -32,7 +31,7 @@ namespace NuClear.ValidationRules.Querying.Host
             // ReSharper disable once AssignNullToNotNullAttribute
             var dllDirectory = Path.Combine(baseDirectory, Environment.Is64BitProcess ? "x64" : "x86");
 
-            _librdkafkaHandle = LoadLibraryEx(Path.Combine(dllDirectory, DllName), IntPtr.Zero, LoadLibraryFlags.LOAD_WITH_ALTERED_SEARCH_PATH);
+            _librdkafkaHandle = LoadLibraryEx(Path.Combine(dllDirectory, DllName), IntPtr.Zero, LoadLibraryFlags.LoadWithAlteredSearchPath);
             if (_librdkafkaHandle == IntPtr.Zero)
             {
                 var lastError = new Win32Exception();

--- a/ValidationRules.Querying.Host/Global.asax.cs
+++ b/ValidationRules.Querying.Host/Global.asax.cs
@@ -8,6 +8,12 @@ namespace NuClear.ValidationRules.Querying.Host
         {
             GlobalConfiguration.Configure(WebApiConfig.Register);
             GlobalConfiguration.Configure(UnityConfig.Register);
+            LibRdKafkaLoader.LoadLibrary();
+        }
+
+        protected void Application_End()
+        {
+            LibRdKafkaLoader.FreeLibrary();
         }
     }
 }

--- a/ValidationRules.Querying.Host/ValidationRules.Querying.Host.csproj
+++ b/ValidationRules.Querying.Host/ValidationRules.Querying.Host.csproj
@@ -140,6 +140,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="App_Start\LibRdKafkaLoader.cs" />
     <Compile Include="App_Start\TelemetryMessageHandler.cs" />
     <Compile Include="App_Start\LocalizationMessageHandler.cs" />
     <Compile Include="App_Start\Int64ToStringConverter.cs" />

--- a/build/metadata.web.psm1
+++ b/build/metadata.web.psm1
@@ -112,16 +112,8 @@ function Get-IisAppPoolMetadata ($Context) {
 
 function Get-IisAppOfflineMetadata ($Context) {
 
-	switch ($Context.EnvType) {
-		{ @('Production', 'Load') -contains $_ } {
-			$takeOffline = $true
-		}
-		default {
-			$takeOffline = $false
-		}
-	}
-	
-	return @{ 'TakeOffline' = $takeOffline }
+	# should always use app_offline.htm to unload librdkafka.dll before deploy
+	return @{ 'TakeOffline' = $true }
 }
 
 function Get-IisMetadata ($Context) {


### PR DESCRIPTION
При старте приложения мы делаем LoadLibrary на librdkafka сами, чтобы получить ownership над ссылкой на dll. (FreeLibrary не отработает если ты не сам загрузил dll а кто-то другой, например DllImportAttribute, ownership будет у него)

DllImport когда сделает ещё раз LoadLibrary то лишь увеличит reference counter на ссылку на dll.

При deploy подкладывается файлик app_offline.htm, который триггерит событие application_end.

На application_end мы два раза вызовем FreeLibrary - за себя и за DllImportAttribute. Нормально вызывать FreeLibrary несколько раз подряд, это не ошибка.

Денис согласился что это единственный корректный способ при работе с IIS, т.к. в IIS на одном apppool сидит много web-приложений, и перезапускать appool это слишком сурово. В .net core в Kestrel там 1 процесс на приложение, там можно было бы обойтись просто подкладыванием файлика app_offline.htm и всё бы работало (если kestel висит позади iis).