### PR TITLE
Исправил запрос версии по состоянию ams

### DIFF
--- a/ValidationRules.Querying.Host/DataAccess/VersioningService.cs
+++ b/ValidationRules.Querying.Host/DataAccess/VersioningService.cs
@@ -65,7 +65,7 @@ namespace NuClear.ValidationRules.Querying.Host.DataAccess
 
                 var version = await Waiter(async () =>
                 {
-                    var amsState = await connectionLocal.GetTable<Version.AmsState>().SingleOrDefaultAsync(x => x.Offset >= offset);
+                    var amsState = await connectionLocal.GetTable<Version.AmsState>().OrderBy(x => x.VersionId).FirstOrDefaultAsync(x => x.Offset >= offset);
                     return amsState?.VersionId;
                 }, interval, timeout);
 


### PR DESCRIPTION
Проблема была в том, что неравенству может соответствовать более одной версии.
Из них нам нужна самая ранняя.