### PR TITLE
[ERM-11235] Изменил уровни критичности сообщений проверки

### DIFF
--- a/ValidationRules.Querying.Host/CheckModes/CheckModeRegistry.cs
+++ b/ValidationRules.Querying.Host/CheckModes/CheckModeRegistry.cs
@@ -27,8 +27,8 @@ namespace NuClear.ValidationRules.Querying.Host.CheckModes
 
                     Rule(MessageTypeCode.OrderPositionAdvertisementMustHaveAdvertisement,
                          single: RuleSeverityLevel.Warning,
-                         manualReport: RuleSeverityLevel.Error,
-                         prerelease: RuleSeverityLevel.Error,
+                         manualReport: RuleSeverityLevel.Warning,
+                         prerelease: RuleSeverityLevel.Warning,
                          release: RuleSeverityLevel.Error),
 
                     Rule(MessageTypeCode.AdvantageousPurchasesBannerMustBeSoldInTheSameCategory,


### PR DESCRIPTION
После релиза erm-ams стало можно не указывать РМ в позициях.
Заглушки перестали использоваться.
По информации от Ярослава, уровень критичности нудно снизить в
режимах "отчёт перед сборкой", "предрелизная сборка".
Ошибка остаётся только в режиме "релиз".