### PR TITLE
Исправил тесты

### DIFF
--- a/Tests/ValidationRules.Replication.Comparison.Tests/RiverService/RiverToErmResultAdapter.cs
+++ b/Tests/ValidationRules.Replication.Comparison.Tests/RiverService/RiverToErmResultAdapter.cs
@@ -71,8 +71,6 @@ namespace ValidationRules.Replication.Comparison.Tests.RiverService
             switch (result.Rule)
             {
                 case 39:
-                case 48:
-                case 49:
                     return result.References.Single(r => r.Type == "Firm").Id;
                 default:
                     return result.MainReference.Id;


### PR DESCRIPTION
Проверки 48, 49 были удалены. Позже под кодом 49 была добавлена другая,
которая имеет другой смысл и не возвращает FirmId.