### PR TITLE
Откат на кастомную сборку librdkafka.redist

### DIFF
--- a/ValidationRules.Querying.Host/ValidationRules.Querying.Host.csproj
+++ b/ValidationRules.Querying.Host/ValidationRules.Querying.Host.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\librdkafka.redist.0.11.1\build\net\librdkafka.redist.props" Condition="Exists('..\packages\librdkafka.redist.0.11.1\build\net\librdkafka.redist.props')" />
+  <Import Project="..\packages\librdkafka.redist.0.11.2-custom\build\net\librdkafka.redist.props" Condition="Exists('..\packages\librdkafka.redist.0.11.2-custom\build\net\librdkafka.redist.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -322,7 +322,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\librdkafka.redist.0.11.1\build\net\librdkafka.redist.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\librdkafka.redist.0.11.1\build\net\librdkafka.redist.props'))" />
+    <Error Condition="!Exists('..\packages\librdkafka.redist.0.11.2-custom\build\net\librdkafka.redist.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\librdkafka.redist.0.11.2-custom\build\net\librdkafka.redist.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/ValidationRules.Querying.Host/packages.config
+++ b/ValidationRules.Querying.Host/packages.config
@@ -14,7 +14,7 @@
   <package id="2GIS.NuClear.Utils" version="1.1.13" targetFramework="net461" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net461" />
   <package id="Confluent.Kafka.StrongName" version="0.11.1" targetFramework="net461" />
-  <package id="librdkafka.redist" version="0.11.1" targetFramework="net461" />
+  <package id="librdkafka.redist" version="0.11.2-custom" targetFramework="net461" />
   <package id="linq2db" version="1.8.3" targetFramework="net461" />
   <package id="log4net" version="2.0.8" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net461" />

--- a/ValidationRules.Replication.Host/ValidationRules.Replication.Host.csproj
+++ b/ValidationRules.Replication.Host/ValidationRules.Replication.Host.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\librdkafka.redist.0.11.1\build\net\librdkafka.redist.props" Condition="Exists('..\packages\librdkafka.redist.0.11.1\build\net\librdkafka.redist.props')" />
+  <Import Project="..\packages\librdkafka.redist.0.11.2-custom\build\net\librdkafka.redist.props" Condition="Exists('..\packages\librdkafka.redist.0.11.2-custom\build\net\librdkafka.redist.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -350,7 +350,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\librdkafka.redist.0.11.1\build\net\librdkafka.redist.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\librdkafka.redist.0.11.1\build\net\librdkafka.redist.props'))" />
+    <Error Condition="!Exists('..\packages\librdkafka.redist.0.11.2-custom\build\net\librdkafka.redist.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\librdkafka.redist.0.11.2-custom\build\net\librdkafka.redist.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/ValidationRules.Replication.Host/packages.config
+++ b/ValidationRules.Replication.Host/packages.config
@@ -51,7 +51,7 @@
   <package id="Dapper.StrongName" version="1.50.2" targetFramework="net461" />
   <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net461" />
   <package id="EnterpriseLibrary.TransientFaultHandling.ServiceBus" version="6.0.1304.0" targetFramework="net461" />
-  <package id="librdkafka.redist" version="0.11.1" targetFramework="net461" />
+  <package id="librdkafka.redist" version="0.11.2-custom" targetFramework="net461" />
   <package id="linq2db" version="1.8.3" targetFramework="net461" />
   <package id="log4net" version="2.0.8" targetFramework="net461" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net461" />

--- a/ValidationRules.StateInitialization.Host/ValidationRules.StateInitialization.Host.csproj
+++ b/ValidationRules.StateInitialization.Host/ValidationRules.StateInitialization.Host.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\librdkafka.redist.0.11.1\build\net\librdkafka.redist.props" Condition="Exists('..\packages\librdkafka.redist.0.11.1\build\net\librdkafka.redist.props')" />
+  <Import Project="..\packages\librdkafka.redist.0.11.2-custom\build\net\librdkafka.redist.props" Condition="Exists('..\packages\librdkafka.redist.0.11.2-custom\build\net\librdkafka.redist.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -250,7 +250,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\librdkafka.redist.0.11.1\build\net\librdkafka.redist.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\librdkafka.redist.0.11.1\build\net\librdkafka.redist.props'))" />
+    <Error Condition="!Exists('..\packages\librdkafka.redist.0.11.2-custom\build\net\librdkafka.redist.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\librdkafka.redist.0.11.2-custom\build\net\librdkafka.redist.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/ValidationRules.StateInitialization.Host/packages.config
+++ b/ValidationRules.StateInitialization.Host/packages.config
@@ -30,7 +30,7 @@
   <package id="Dapper.StrongName" version="1.50.2" targetFramework="net461" />
   <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net461" />
   <package id="EnterpriseLibrary.TransientFaultHandling.ServiceBus" version="6.0.1304.0" targetFramework="net461" />
-  <package id="librdkafka.redist" version="0.11.1" targetFramework="net461" />
+  <package id="librdkafka.redist" version="0.11.2-custom" targetFramework="net461" />
   <package id="linq2db" version="1.8.3" targetFramework="net461" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />


### PR DESCRIPTION
Со стандартной версией 0.11.1 возникала рассинхронизация РМ между AMS и VR - сотни РМ в день не совпадали.

Не стали досконально разбираться в причинах - решили откатиться на версию librdkafka на которой всё работает.
Позже можно опять попробовать вернуться на стандартную версию, может быть на ней уже всё будет работать.