### PR TITLE
понизить критичность проверки

### DIFF
--- a/ValidationRules.Querying.Host/CheckModes/CheckModeRegistry.cs
+++ b/ValidationRules.Querying.Host/CheckModes/CheckModeRegistry.cs
@@ -221,7 +221,7 @@ namespace NuClear.ValidationRules.Querying.Host.CheckModes
                          release: RuleSeverityLevel.Error),
 
                     Rule(MessageTypeCode.OrderMustNotIncludeReleasedPeriod,
-                         single: RuleSeverityLevel.Error),
+                         single: RuleSeverityLevel.Warning),
 
                     Rule(MessageTypeCode.OrderMustUseCategoriesOnlyAvailableInProject,
                          single: RuleSeverityLevel.Error,


### PR DESCRIPTION
Появляется возможность оформлять заказ на период для которого уже есть дествующий релиз. Необходимо избавиться от соответсвующей проверки. В рамках expidite решено, понизить критичность ошибок ERROR->Warning. Далее в рамках работ по заказу с любой даты, возможно совсем выпилим проверку.