### PR TITLE
Получше сделал retrying в poll loop

### DIFF
--- a/ValidationRules.Hosting.Common/KafkaMessageFlowReceiverFactory.cs
+++ b/ValidationRules.Hosting.Common/KafkaMessageFlowReceiverFactory.cs
@@ -161,17 +161,12 @@ namespace ValidationRules.Hosting.Common
                     {
                         _consumer.OnMessage += OnMessage;
 
-                        // retry loop
+                        // retryable poll loop
                         while (!cancellationToken.IsCancellationRequested)
                         {
                             try
                             {
-                                // poll loop
-                                while (!cancellationToken.IsCancellationRequested)
-                                {
-                                    _consumer.Poll(_pollTimeout);
-                                }
-
+                                _consumer.Poll(_pollTimeout);
                             }
                             catch (Exception ex)
                             {

--- a/ValidationRules.Hosting.Common/KafkaMessageFlowReceiverFactory.cs
+++ b/ValidationRules.Hosting.Common/KafkaMessageFlowReceiverFactory.cs
@@ -39,6 +39,9 @@ namespace ValidationRules.Hosting.Common
             {
                 var privateConfig = new Dictionary<string, object>(settings.Config)
                 {
+                    // help kafka server logs to identify node
+                    { "client.id", Environment.MachineName },
+
                     // manual commit
                     { "enable.auto.commit", false },
 
@@ -98,7 +101,7 @@ namespace ValidationRules.Hosting.Common
                 }
 
                 // kafka docs: errors should be seen as informational rather than catastrophic
-                private void OnError(object sender, Error error) => _tracer.Warn(error.Reason);
+                private void OnError(object sender, Error error) => _tracer.Warn($"KafkaAudit - error {error.Reason}");
 
                 private void OnPartitionsAssigned(object sender, List<TopicPartition> list)
                 {
@@ -158,16 +161,23 @@ namespace ValidationRules.Hosting.Common
                     {
                         _consumer.OnMessage += OnMessage;
 
-                        // loop
+                        // retry loop
                         while (!cancellationToken.IsCancellationRequested)
                         {
-                            _consumer.Poll(_pollTimeout);
+                            try
+                            {
+                                // poll loop
+                                while (!cancellationToken.IsCancellationRequested)
+                                {
+                                    _consumer.Poll(_pollTimeout);
+                                }
+
+                            }
+                            catch (Exception ex)
+                            {
+                                _tracer.Warn(ex, "KafkaAudit - error in poll loop, retrying");
+                            }
                         }
-                    }
-                    catch (Exception ex)
-                    {
-                        _tracer.Warn(ex, "Kafka audit - exception in poll loop");
-                        StartNew();
                     }
                     finally
                     {
@@ -181,7 +191,7 @@ namespace ValidationRules.Hosting.Common
                             _messages.Add(message);
                         }
 
-                        _tracer.Info($"KafkaAudit - fetch message {message.Offset}");
+                        _tracer.Info($"KafkaAudit - fetch message {message.TopicPartitionOffset}");
                     }
                 }
 
@@ -190,7 +200,7 @@ namespace ValidationRules.Hosting.Common
                     lock (_messages)
                     {
                         var batch = _messages.OrderByOffset().Take(batchSize).ToList();
-                        _tracer.Info(batch.Count != 0 ? $"KafkaAudit - receive batch [{batch.First().Offset.Value} - {batch.Last().Offset.Value}]" : "KafkaAudit - empty batch");
+                        _tracer.Info(batch.Count != 0 ? $"KafkaAudit - receive batch { batch.First().TopicPartition } @{batch.First().Offset.Value}-{batch.Last().Offset.Value}" : "KafkaAudit - empty batch");
 
                         return batch;
                     }
@@ -208,13 +218,15 @@ namespace ValidationRules.Hosting.Common
                     var committedOffsets = _consumer.CommitAsync(maxOffsetMessage).GetAwaiter().GetResult();
                     if (committedOffsets.Error.HasError)
                     {
+                        _tracer.Warn($"KafkaAudit - error occured while committing offsets {committedOffsets.Error}");
                         throw new KafkaException(committedOffsets.Error);
                     }
 
-                    var fail = committedOffsets.Offsets.FirstOrDefault(x => x.Error.HasError);
-                    if (fail != null)
+                    var failOffset = committedOffsets.Offsets.FirstOrDefault(x => x.Error.HasError);
+                    if (failOffset != null)
                     {
-                        throw new KafkaException(fail.Error);
+                        _tracer.Warn($"KafkaAudit - error occured while committing offset {failOffset}");
+                        throw new KafkaException(failOffset.Error);
                     }
 
                     lock (_messages)
@@ -225,7 +237,7 @@ namespace ValidationRules.Hosting.Common
 
                     foreach (var committedOffset in committedOffsets.Offsets)
                     {
-                        _tracer.Info($"KafkaAudit - committed offset {committedOffset.Offset.Value}");
+                        _tracer.Info($"KafkaAudit - committed offset {committedOffset}");
                     }
                 }
 


### PR DESCRIPTION
Также поменял логгирование
- сообщения в логах имеют префикс KafkaAudit
- выставляю "client.id" как hostname для удобства мониторигна на стороне kafka cluster. По умолчанию там слово rdkafka-{guid}, что не очень наглядно.