### PR TITLE
Fix #331 Увеличил интервал для проверки "AMS жив"

### DIFF
--- a/ValidationRules.Replication.Host/Jobs/HeartbeatJob.cs
+++ b/ValidationRules.Replication.Host/Jobs/HeartbeatJob.cs
@@ -20,7 +20,7 @@ namespace NuClear.ValidationRules.Replication.Host.Jobs
 {
     public sealed class HeartbeatJob : TaskServiceJobBase
     {
-        private static readonly TimeSpan AmsSyncInterval = TimeSpan.FromSeconds(20);
+        private static readonly TimeSpan AmsSyncInterval = TimeSpan.FromMinutes(1);
 
         private readonly KafkaMessageFlowInfoProvider _kafkaMessageFlowInfoProvider;
         private readonly IRepository<SystemStatus> _repository;


### PR DESCRIPTION
Интевала в 20 секунд, пожалуй, недостаточно. Был прецедент что просто разошлось время на серверах и проверка ложно сработала.

Решил увеличить интервал до минуты - это ещё не критично с точки зрения бизнеса, но заметно глазом, если разошлось время на серверах (обычно если время разошлось меньше чем на минуту то это не заметно, т.к. на UI время выводится с точностью до минуты)

fixes #331